### PR TITLE
Bugfix: Only mark buttons as checked if a key was down

### DIFF
--- a/ConsoleGame/KeyboardInputReader.cpp
+++ b/ConsoleGame/KeyboardInputReader.cpp
@@ -34,14 +34,14 @@ void KeyboardInputReader::ReadInput()
       {
          _buttonStates.at( it->second ).ButtonWasPressed = !_buttonStates.at( it->second ).ButtonIsDown;
          _buttonStates.at( it->second ).ButtonIsDown = true;
+
+         checkedButtons.push_back( it->second );
       }
       else
       {
          _buttonStates.at( it->second ).ButtonWasPressed = false;
          _buttonStates.at( it->second ).ButtonIsDown = false;
       }
-
-      checkedButtons.push_back( it->second );
    }
 }
 


### PR DESCRIPTION
## Description

I noticed that although I set up three different keys that map to the "A" button, only one of them was working. That's because after checking whether the first key is down, we marked the button as "checked", then we skip the next two keys. To fix it, I just moved the "mark as checked" line, now we only mark a button as "checked" if one of the corresponding keys is actually down.