### PR TITLE
Band Aid: Set the console buffer dimensions to match the console's default dimensions

### DIFF
--- a/ConsoleGame/ConsoleDrawer.cpp
+++ b/ConsoleGame/ConsoleDrawer.cpp
@@ -30,14 +30,17 @@ ConsoleDrawer::~ConsoleDrawer()
 
 void ConsoleDrawer::Initialize()
 {
-   // TODO: can we get the character size and use it here?
-   //auto consoleHandle = GetConsoleWindow();
-   //RECT consoleRect;
-   //GetWindowRect( consoleHandle, &consoleRect );
-   //MoveWindow( consoleHandle, consoleRect.left, consoleRect.top, 800, 600, TRUE );
+   SetConsoleScreenBufferSize( _outputHandle, { _consoleSize.X, _consoleSize.Y } );
 
-   // TODO: there HAS to be a better way to do this, maybe with the code above...
-   system( format("MODE CON COLS={0} LINES={1}", _consoleSize.X, _consoleSize.Y ).c_str() );
+   // TODO: as of the Windows 11 update I installed on 11/09/2022,
+   // SetConsoleWindowInfo is no longer resizing the console window.
+   // I'm commenting this out because it actually causes a weird issue
+   // where the console scrolls downward indefinitely.
+   SMALL_RECT windowCoords{ 0, 0, _consoleSize.X - 1, _consoleSize.Y - 1 };
+   SetConsoleWindowInfo( _outputHandle, TRUE, &windowCoords);
+
+   // TODO: I tried this as well, it doesn't work either.
+   //system( format("MODE CON COLS={0} LINES={1}", _consoleSize.X, _consoleSize.Y ).c_str() );
 
    SetCursorVisibility( false );
    ClearDrawBuffer();
@@ -118,6 +121,7 @@ void ConsoleDrawer::Draw( int left, int top, const string& buffer, ConsoleColor 
 
 void ConsoleDrawer::FlipDrawBuffer()
 {
+   // MUFFINS: the console is scrolling super fast, why is it scrolling at all?
    WriteConsoleOutput( _outputHandle, _drawBuffer, _consoleSize, _zeroCoordinate, &_outputRect );
 }
 

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -75,8 +75,10 @@ shared_ptr<GameRenderConfig> BuildRenderConfig()
 {
    auto renderConfig = make_shared<GameRenderConfig>();
 
+   // TODO: don't change these dimensions until we figure out the issue with console resizing.
+   // (see ConsoleDrawer.cpp)
    renderConfig->ConsoleWidth = 120;
-   renderConfig->ConsoleHeight = 32;
+   renderConfig->ConsoleHeight = 30;
 
    renderConfig->DefaultForegroundColor = ConsoleColor::Grey;
    renderConfig->DefaultBackgroundColor = ConsoleColor::Black;

--- a/ConsoleGame/StartupStateConsoleRenderer.cpp
+++ b/ConsoleGame/StartupStateConsoleRenderer.cpp
@@ -26,14 +26,14 @@ void StartupStateConsoleRenderer::Render()
 
    auto middleX = _renderConfig->ConsoleWidth / 2;
 
-   _consoleDrawer->Draw( middleX - 26, 2, ".==================================================." );
-   _consoleDrawer->Draw( middleX - 27, 3, "|          WELCOME TO (INSERT YOUR TITLE)!!          |" );
-   _consoleDrawer->Draw( middleX - 26, 4, "`=================================================='" );
+   _consoleDrawer->Draw( middleX - 26, 1, ".==================================================." );
+   _consoleDrawer->Draw( middleX - 27, 2, "|          WELCOME TO (INSERT YOUR TITLE)!!          |" );
+   _consoleDrawer->Draw( middleX - 26, 3, "`=================================================='" );
 
-   _consoleDrawer->Draw( middleX - 30, 7, "They sky's the limit! Er, the console is the limit, I guess." );
-   _consoleDrawer->Draw( middleX - 40, 8, "Just to get you started, here's a list of which keys are bound to which buttons:" );
+   _consoleDrawer->Draw( middleX - 30, 6, "They sky's the limit! Er, the console is the limit, I guess." );
+   _consoleDrawer->Draw( middleX - 40, 7, "Just to get you started, here's a list of which keys are bound to which buttons:" );
 
-   int top = 10;
+   int top = 9;
 
    DrawKeyBindings( middleX, top );
 


### PR DESCRIPTION
Associated Issue: #4 

## Description

As stated in the associated issue, there's a problem with resizing the console window after a Windows 11 update. I don't want this to halt development, so I temporarily set the console size in the config to match the default size of the new console window. Now the console doesn't scroll indefinitely anymore, but unfortunately we also can't change the size of the console. I'm also not sure if this would even work on other machines, but it'll have to do for now.