### PR TITLE
Add unit testing framework with some tests

### DIFF
--- a/ConsoleGame.sln
+++ b/ConsoleGame.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.32510.428
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ConsoleGame", "ConsoleGame\ConsoleGame.vcxproj", "{F1E9B035-58DB-4E2A-9400-A9FF4D73DA01}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ConsoleGameTests", "ConsoleGameTests\ConsoleGameTests.vcxproj", "{4076DD39-2990-436A-A91F-CB6CB9B0799B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -21,6 +23,14 @@ Global
 		{F1E9B035-58DB-4E2A-9400-A9FF4D73DA01}.Release|x64.Build.0 = Release|x64
 		{F1E9B035-58DB-4E2A-9400-A9FF4D73DA01}.Release|x86.ActiveCfg = Release|Win32
 		{F1E9B035-58DB-4E2A-9400-A9FF4D73DA01}.Release|x86.Build.0 = Release|Win32
+		{4076DD39-2990-436A-A91F-CB6CB9B0799B}.Debug|x64.ActiveCfg = Debug|x64
+		{4076DD39-2990-436A-A91F-CB6CB9B0799B}.Debug|x64.Build.0 = Debug|x64
+		{4076DD39-2990-436A-A91F-CB6CB9B0799B}.Debug|x86.ActiveCfg = Debug|Win32
+		{4076DD39-2990-436A-A91F-CB6CB9B0799B}.Debug|x86.Build.0 = Debug|Win32
+		{4076DD39-2990-436A-A91F-CB6CB9B0799B}.Release|x64.ActiveCfg = Release|x64
+		{4076DD39-2990-436A-A91F-CB6CB9B0799B}.Release|x64.Build.0 = Release|x64
+		{4076DD39-2990-436A-A91F-CB6CB9B0799B}.Release|x86.ActiveCfg = Release|Win32
+		{4076DD39-2990-436A-A91F-CB6CB9B0799B}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ConsoleGame/ConsoleDrawer.cpp
+++ b/ConsoleGame/ConsoleDrawer.cpp
@@ -7,7 +7,7 @@
 using namespace std;
 using namespace ConsoleGame;
 
-ConsoleDrawer::ConsoleDrawer( const shared_ptr<GameRenderConfig>& renderConfig )
+ConsoleDrawer::ConsoleDrawer( const shared_ptr<GameRenderConfig> renderConfig )
    : _renderConfig( renderConfig ),
      _outputHandle( GetStdHandle( STD_OUTPUT_HANDLE ) ),
      _consoleSize( { _renderConfig->ConsoleWidth, _renderConfig->ConsoleHeight } ),

--- a/ConsoleGame/ConsoleDrawer.h
+++ b/ConsoleGame/ConsoleDrawer.h
@@ -14,7 +14,7 @@ namespace ConsoleGame
    class ConsoleDrawer : public IConsoleDrawer
    {
    public:
-      ConsoleDrawer( const std::shared_ptr<GameRenderConfig>& renderConfig );
+      ConsoleDrawer( const std::shared_ptr<GameRenderConfig> renderConfig );
       ~ConsoleDrawer();
 
       void Initialize() override;
@@ -38,7 +38,7 @@ namespace ConsoleGame
       unsigned short ConsoleColorsToAttribute( ConsoleColor foregroundColor, ConsoleColor backgroundColor );
 
    private:
-      const std::shared_ptr<GameRenderConfig>& _renderConfig;
+      const std::shared_ptr<GameRenderConfig> _renderConfig;
 
       HANDLE _outputHandle;
       COORD _consoleSize;

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -5,6 +5,8 @@
 #include "GameInputConfig.h"
 #include "KeyCode.h"
 #include "GameButton.h"
+#include "HighResolutionClockWrapper.h"
+#include "SleeperWrapper.h"
 #include "GameEventAggregator.h"
 #include "GameClock.h"
 #include "KeyboardInputReader.h"
@@ -38,9 +40,13 @@ int main()
 
    auto config = BuildGameConfig();
 
+   // wrappers
+   auto highResolutionClockWrapper = shared_ptr<HighResolutionClockWrapper>( new HighResolutionClockWrapper() );
+   auto sleeperWrapper = shared_ptr<SleeperWrapper>( new SleeperWrapper() );
+
    // auxiliary objects
    auto eventAggregator = shared_ptr<GameEventAggregator>( new GameEventAggregator() );
-   auto clock = shared_ptr<GameClock>( new GameClock( config->FramesPerSecond ) );
+   auto clock = shared_ptr<GameClock>( new GameClock( highResolutionClockWrapper, sleeperWrapper, config->FramesPerSecond ) );
    auto keyboardInputReader = shared_ptr<KeyboardInputReader>( new KeyboardInputReader( config->InputConfig ) );
 
    // game data objects

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -7,6 +7,7 @@
 #include "GameButton.h"
 #include "HighResolutionClockWrapper.h"
 #include "SleeperWrapper.h"
+#include "KeyboardWrapper.h"
 #include "GameEventAggregator.h"
 #include "GameClock.h"
 #include "KeyboardInputReader.h"
@@ -41,13 +42,14 @@ int main()
    auto config = BuildGameConfig();
 
    // wrappers
-   auto highResolutionClockWrapper = shared_ptr<HighResolutionClockWrapper>( new HighResolutionClockWrapper() );
-   auto sleeperWrapper = shared_ptr<SleeperWrapper>( new SleeperWrapper() );
+   auto highResolutionClock = shared_ptr<HighResolutionClockWrapper>( new HighResolutionClockWrapper() );
+   auto sleeper = shared_ptr<SleeperWrapper>( new SleeperWrapper() );
+   auto keyboard = shared_ptr<IKeyboard>( new KeyboardWrapper() );
 
    // auxiliary objects
    auto eventAggregator = shared_ptr<GameEventAggregator>( new GameEventAggregator() );
-   auto clock = shared_ptr<GameClock>( new GameClock( highResolutionClockWrapper, sleeperWrapper, config->FramesPerSecond ) );
-   auto keyboardInputReader = shared_ptr<KeyboardInputReader>( new KeyboardInputReader( config->InputConfig ) );
+   auto clock = shared_ptr<GameClock>( new GameClock( highResolutionClock, sleeper, config->FramesPerSecond ) );
+   auto keyboardInputReader = shared_ptr<KeyboardInputReader>( new KeyboardInputReader( config->InputConfig, keyboard ) );
 
    // game data objects
    auto game = shared_ptr<Game>( new Game( config, eventAggregator ) );

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -187,6 +187,7 @@
     <ClInclude Include="GameInputHandler.h" />
     <ClInclude Include="GameInputConfig.h" />
     <ClInclude Include="IGameStateProvider.h" />
+    <ClInclude Include="IHighResolutionClock.h" />
     <ClInclude Include="IPlayerInfoProvider.h" />
     <ClInclude Include="KeyboardInputReader.h" />
     <ClInclude Include="KeyCode.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="KeyboardInputReader.cpp" />
     <ClCompile Include="PlayingStateConsoleRenderer.cpp" />
     <ClCompile Include="PlayingStateInputHandler.cpp" />
+    <ClCompile Include="SleeperWrapper.cpp" />
     <ClCompile Include="StartupStateConsoleRenderer.cpp" />
     <ClCompile Include="StartupStateInputHandler.cpp" />
   </ItemGroup>
@@ -195,6 +196,7 @@
     <ClInclude Include="KeyCode.h" />
     <ClInclude Include="PlayingStateConsoleRenderer.h" />
     <ClInclude Include="PlayingStateInputHandler.h" />
+    <ClInclude Include="SleeperWrapper.h" />
     <ClInclude Include="StartupStateInputHandler.h" />
     <ClInclude Include="StartupStateConsoleRenderer.h" />
   </ItemGroup>

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -190,6 +190,7 @@
     <ClInclude Include="IGameStateProvider.h" />
     <ClInclude Include="IHighResolutionClock.h" />
     <ClInclude Include="IPlayerInfoProvider.h" />
+    <ClInclude Include="ISleeper.h" />
     <ClInclude Include="KeyboardInputReader.h" />
     <ClInclude Include="KeyCode.h" />
     <ClInclude Include="PlayingStateConsoleRenderer.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -176,6 +176,7 @@
     <ClInclude Include="GameRenderConfig.h" />
     <ClInclude Include="GameRunner.h" />
     <ClInclude Include="GameState.h" />
+    <ClInclude Include="HighResolutionClockWrapper.h" />
     <ClInclude Include="IGameCommandExecutor.h" />
     <ClInclude Include="IConsoleDrawer.h" />
     <ClInclude Include="IGameClock.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -156,6 +156,7 @@
     <ClCompile Include="GameInputHandler.cpp" />
     <ClCompile Include="HighResolutionClockWrapper.cpp" />
     <ClCompile Include="KeyboardInputReader.cpp" />
+    <ClCompile Include="KeyboardWrapper.cpp" />
     <ClCompile Include="PlayingStateConsoleRenderer.cpp" />
     <ClCompile Include="PlayingStateInputHandler.cpp" />
     <ClCompile Include="SleeperWrapper.cpp" />
@@ -178,6 +179,7 @@
     <ClInclude Include="GameRenderConfig.h" />
     <ClInclude Include="GameRunner.h" />
     <ClInclude Include="GameState.h" />
+    <ClInclude Include="KeyboardWrapper.h" />
     <ClInclude Include="HighResolutionClockWrapper.h" />
     <ClInclude Include="IGameCommandExecutor.h" />
     <ClInclude Include="IConsoleDrawer.h" />
@@ -191,6 +193,7 @@
     <ClInclude Include="GameInputConfig.h" />
     <ClInclude Include="IGameStateProvider.h" />
     <ClInclude Include="IHighResolutionClock.h" />
+    <ClInclude Include="IKeyboard.h" />
     <ClInclude Include="IPlayerInfoProvider.h" />
     <ClInclude Include="ISleeper.h" />
     <ClInclude Include="KeyboardInputReader.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -154,6 +154,7 @@
     <ClCompile Include="GameEventAggregator.cpp" />
     <ClCompile Include="GameRunner.cpp" />
     <ClCompile Include="GameInputHandler.cpp" />
+    <ClCompile Include="HighResolutionClockWrapper.cpp" />
     <ClCompile Include="KeyboardInputReader.cpp" />
     <ClCompile Include="PlayingStateConsoleRenderer.cpp" />
     <ClCompile Include="PlayingStateInputHandler.cpp" />

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -34,6 +34,9 @@
     <Filter Include="Header Files\Config">
       <UniqueIdentifier>{3d844f74-be55-4dd0-b069-ece15e0fba1b}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\Wrappers">
+      <UniqueIdentifier>{82f7e089-e48f-47eb-a1b9-e2f92e1392e4}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ConsoleGame.cpp">
@@ -181,6 +184,9 @@
     </ClInclude>
     <ClInclude Include="IHighResolutionClock.h">
       <Filter>Header Files\Interfaces</Filter>
+    </ClInclude>
+    <ClInclude Include="HighResolutionClockWrapper.h">
+      <Filter>Header Files\Wrappers</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -37,6 +37,9 @@
     <Filter Include="Header Files\Wrappers">
       <UniqueIdentifier>{82f7e089-e48f-47eb-a1b9-e2f92e1392e4}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Wrappers">
+      <UniqueIdentifier>{60b226f4-2879-4bda-8b14-6cffa8d37e50}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ConsoleGame.cpp">
@@ -80,6 +83,9 @@
     </ClCompile>
     <ClCompile Include="PlayingStateConsoleRenderer.cpp">
       <Filter>Source Files\Render</Filter>
+    </ClCompile>
+    <ClCompile Include="SleeperWrapper.cpp">
+      <Filter>Source Files\Wrappers</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -190,6 +196,9 @@
     </ClInclude>
     <ClInclude Include="ISleeper.h">
       <Filter>Header Files\Interfaces</Filter>
+    </ClInclude>
+    <ClInclude Include="SleeperWrapper.h">
+      <Filter>Header Files\Wrappers</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClCompile Include="HighResolutionClockWrapper.cpp">
       <Filter>Source Files\Wrappers</Filter>
     </ClCompile>
+    <ClCompile Include="KeyboardWrapper.cpp">
+      <Filter>Source Files\Wrappers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">
@@ -201,6 +204,12 @@
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
     <ClInclude Include="SleeperWrapper.h">
+      <Filter>Header Files\Wrappers</Filter>
+    </ClInclude>
+    <ClInclude Include="IKeyboard.h">
+      <Filter>Header Files\Interfaces</Filter>
+    </ClInclude>
+    <ClInclude Include="KeyboardWrapper.h">
       <Filter>Header Files\Wrappers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -188,5 +188,8 @@
     <ClInclude Include="HighResolutionClockWrapper.h">
       <Filter>Header Files\Wrappers</Filter>
     </ClInclude>
+    <ClInclude Include="ISleeper.h">
+      <Filter>Header Files\Interfaces</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -179,5 +179,8 @@
     <ClInclude Include="Direction.h">
       <Filter>Header Files\DataTypes</Filter>
     </ClInclude>
+    <ClInclude Include="IHighResolutionClock.h">
+      <Filter>Header Files\Interfaces</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -87,6 +87,9 @@
     <ClCompile Include="SleeperWrapper.cpp">
       <Filter>Source Files\Wrappers</Filter>
     </ClCompile>
+    <ClCompile Include="HighResolutionClockWrapper.cpp">
+      <Filter>Source Files\Wrappers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameRunner.h">

--- a/ConsoleGame/DiagnosticsConsoleRenderer.cpp
+++ b/ConsoleGame/DiagnosticsConsoleRenderer.cpp
@@ -11,9 +11,9 @@
 using namespace std;
 using namespace ConsoleGame;
 
-DiagnosticsConsoleRenderer::DiagnosticsConsoleRenderer( const shared_ptr<IConsoleDrawer>& consoleDrawer,
-                                                        const shared_ptr<IGameClock>& clock,
-                                                        const shared_ptr<GameRenderConfig>& renderConfig )
+DiagnosticsConsoleRenderer::DiagnosticsConsoleRenderer( const shared_ptr<IConsoleDrawer> consoleDrawer,
+                                                        const shared_ptr<IGameClock> clock,
+                                                        const shared_ptr<GameRenderConfig> renderConfig )
    : _consoleDrawer( consoleDrawer ),
      _clock( clock ),
      _renderConfig( renderConfig )

--- a/ConsoleGame/DiagnosticsConsoleRenderer.h
+++ b/ConsoleGame/DiagnosticsConsoleRenderer.h
@@ -13,15 +13,15 @@ namespace ConsoleGame
    class DiagnosticsConsoleRenderer : public IGameRenderer
    {
    public:
-      DiagnosticsConsoleRenderer( const std::shared_ptr<IConsoleDrawer>& consoleDrawer,
-                                  const std::shared_ptr<IGameClock>& clock,
-                                  const std::shared_ptr<GameRenderConfig>& renderConfig );
+      DiagnosticsConsoleRenderer( const std::shared_ptr<IConsoleDrawer> consoleDrawer,
+                                  const std::shared_ptr<IGameClock> clock,
+                                  const std::shared_ptr<GameRenderConfig> renderConfig );
 
       void Render() override;
 
    private:
       const std::shared_ptr<IConsoleDrawer> _consoleDrawer;
-      const std::shared_ptr<IGameClock>& _clock;
-      const std::shared_ptr<GameRenderConfig>& _renderConfig;
+      const std::shared_ptr<IGameClock> _clock;
+      const std::shared_ptr<GameRenderConfig> _renderConfig;
    };
 }

--- a/ConsoleGame/Game.cpp
+++ b/ConsoleGame/Game.cpp
@@ -9,8 +9,8 @@
 using namespace std;
 using namespace ConsoleGame;
 
-Game::Game( const std::shared_ptr<GameConfig>& config,
-            const std::shared_ptr<IGameEventAggregator>& eventAggregator )
+Game::Game( const std::shared_ptr<GameConfig> config,
+            const std::shared_ptr<IGameEventAggregator> eventAggregator )
    : _config( config ),
      _eventAggregator( eventAggregator ),
      _state( GameState::Startup ),

--- a/ConsoleGame/Game.h
+++ b/ConsoleGame/Game.h
@@ -19,8 +19,8 @@ namespace ConsoleGame
       public IPlayerInfoProvider
    {
    public:
-      Game( const std::shared_ptr<GameConfig>& config,
-            const std::shared_ptr<IGameEventAggregator>& eventAggregator );
+      Game( const std::shared_ptr<GameConfig> config,
+            const std::shared_ptr<IGameEventAggregator> eventAggregator );
 
       GameState GetGameState() const override { return _state; }
 
@@ -31,8 +31,8 @@ namespace ConsoleGame
       int GetPlayerYPosition() const override { return _playerPositionY; }
 
    private:
-      const std::shared_ptr<GameConfig>& _config;
-      const std::shared_ptr<IGameEventAggregator>& _eventAggregator;
+      const std::shared_ptr<GameConfig> _config;
+      const std::shared_ptr<IGameEventAggregator> _eventAggregator;
 
       GameState _state;
 

--- a/ConsoleGame/GameClock.cpp
+++ b/ConsoleGame/GameClock.cpp
@@ -40,7 +40,7 @@ void GameClock::Tick()
    }
 
    auto elapsedFrameTimeNano = _highResolutionClock->Now() - _frameStartTimeNano;
-   auto remainingFrameTimeNano = _nanoSecondsPerFrame - elapsedFrameTimeNano.count();
+   auto remainingFrameTimeNano = _nanoSecondsPerFrame - elapsedFrameTimeNano;
 
    if ( remainingFrameTimeNano > 0ll )
    {

--- a/ConsoleGame/GameClock.cpp
+++ b/ConsoleGame/GameClock.cpp
@@ -39,7 +39,9 @@ void GameClock::Tick()
       return;
    }
 
-   auto elapsedFrameTimeNano = _highResolutionClock->Now() - _frameStartTimeNano;
+   auto nowNano = _highResolutionClock->Now();
+
+   auto elapsedFrameTimeNano = nowNano - _frameStartTimeNano;
    auto remainingFrameTimeNano = _nanoSecondsPerFrame - elapsedFrameTimeNano;
 
    if ( remainingFrameTimeNano > 0ll )
@@ -52,7 +54,7 @@ void GameClock::Tick()
    }
 
    _totalFrameCount++;
-   _frameStartTimeNano = _highResolutionClock->Now();
+   _frameStartTimeNano = nowNano;
 }
 
 void GameClock::Stop()

--- a/ConsoleGame/GameClock.h
+++ b/ConsoleGame/GameClock.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <chrono>
 
 #include "IGameClock.h"
 
@@ -32,7 +31,7 @@ namespace ConsoleGame
       int _framesPerSecond;
       long long _totalFrameCount;
       long long _lagFrameCount;
-      std::chrono::steady_clock::time_point _frameStartTimeNano;
+      long long _frameStartTimeNano;
       long long _nanoSecondsPerFrame;
       bool _isRunning;
    };

--- a/ConsoleGame/GameClock.h
+++ b/ConsoleGame/GameClock.h
@@ -1,15 +1,21 @@
 #pragma once
 
+#include <memory>
 #include <chrono>
 
 #include "IGameClock.h"
 
 namespace ConsoleGame
 {
+   class IHighResolutionClock;
+   class ISleeper;
+
    class GameClock : public IGameClock
    {
    public:
-      GameClock( int framesPerSecond );
+      GameClock( const std::shared_ptr<IHighResolutionClock> highResolutionClock,
+                 const std::shared_ptr<ISleeper> sleeper,
+                 int framesPerSecond );
 
       void Start() override;
       void Tick() override;
@@ -20,6 +26,9 @@ namespace ConsoleGame
       long long GetLagFrameCount() const override { return _lagFrameCount; }
 
    private:
+      const std::shared_ptr<IHighResolutionClock> _highResolutionClock;
+      const std::shared_ptr<ISleeper> _sleeper;
+
       int _framesPerSecond;
       long long _totalFrameCount;
       long long _lagFrameCount;

--- a/ConsoleGame/GameConsoleRenderer.cpp
+++ b/ConsoleGame/GameConsoleRenderer.cpp
@@ -12,11 +12,11 @@
 using namespace std;
 using namespace ConsoleGame;
 
-GameConsoleRenderer::GameConsoleRenderer( const shared_ptr<GameRenderConfig>& renderConfig,
-                                          const shared_ptr<IConsoleDrawer>& consoleDrawer,
-                                          const shared_ptr<IGameStateProvider>& stateProvider,
-                                          const shared_ptr<IGameRenderer>& diagnosticsRenderer,
-                                          const shared_ptr<IGameEventAggregator>& eventAggregator )
+GameConsoleRenderer::GameConsoleRenderer( const shared_ptr<GameRenderConfig> renderConfig,
+                                          const shared_ptr<IConsoleDrawer> consoleDrawer,
+                                          const shared_ptr<IGameStateProvider> stateProvider,
+                                          const shared_ptr<IGameRenderer> diagnosticsRenderer,
+                                          const shared_ptr<IGameEventAggregator> eventAggregator )
    : _consoleDrawer( consoleDrawer ),
      _stateProvider( stateProvider ),
      _diagnosticsRenderer( diagnosticsRenderer ),

--- a/ConsoleGame/GameConsoleRenderer.h
+++ b/ConsoleGame/GameConsoleRenderer.h
@@ -18,11 +18,11 @@ namespace ConsoleGame
    class GameConsoleRenderer : public IGameRenderer
    {
    public:
-      GameConsoleRenderer( const std::shared_ptr<GameRenderConfig>& renderConfig,
-                           const std::shared_ptr<IConsoleDrawer>& consoleDrawer,
-                           const std::shared_ptr<IGameStateProvider>& stateProvider,
-                           const std::shared_ptr<IGameRenderer>& diagnosticsRenderer,
-                           const std::shared_ptr<IGameEventAggregator>& eventAggregator );
+      GameConsoleRenderer( const std::shared_ptr<GameRenderConfig> renderConfig,
+                           const std::shared_ptr<IConsoleDrawer> consoleDrawer,
+                           const std::shared_ptr<IGameStateProvider> stateProvider,
+                           const std::shared_ptr<IGameRenderer> diagnosticsRenderer,
+                           const std::shared_ptr<IGameEventAggregator> eventAggregator );
 
       void AddRendererForGameState( GameState state, std::shared_ptr<IGameRenderer> renderer );
 
@@ -33,9 +33,9 @@ namespace ConsoleGame
       void HandleToggleDiagnosticsEvent();
 
    private:
-      const std::shared_ptr<IConsoleDrawer>& _consoleDrawer;
-      const std::shared_ptr<IGameStateProvider>& _stateProvider;
-      const std::shared_ptr<IGameRenderer>& _diagnosticsRenderer;
+      const std::shared_ptr<IConsoleDrawer> _consoleDrawer;
+      const std::shared_ptr<IGameStateProvider> _stateProvider;
+      const std::shared_ptr<IGameRenderer> _diagnosticsRenderer;
 
       std::map<GameState, std::shared_ptr<IGameRenderer>> _stateRenderers;
 

--- a/ConsoleGame/GameInputHandler.cpp
+++ b/ConsoleGame/GameInputHandler.cpp
@@ -9,9 +9,9 @@
 using namespace std;
 using namespace ConsoleGame;
 
-GameInputHandler::GameInputHandler( const shared_ptr<IGameInputReader>& inputReader,
-                                    const shared_ptr<IGameStateProvider>& stateProvider,
-                                    const shared_ptr<IGameEventAggregator>& eventAggregator )
+GameInputHandler::GameInputHandler( const shared_ptr<IGameInputReader> inputReader,
+                                    const shared_ptr<IGameStateProvider> stateProvider,
+                                    const shared_ptr<IGameEventAggregator> eventAggregator )
    : _inputReader( inputReader ),
      _stateProvider( stateProvider ),
      _eventAggregator( eventAggregator )

--- a/ConsoleGame/GameInputHandler.h
+++ b/ConsoleGame/GameInputHandler.h
@@ -15,9 +15,9 @@ namespace ConsoleGame
    class GameInputHandler : public IGameInputHandler
    {
    public:
-      GameInputHandler( const std::shared_ptr<IGameInputReader>& inputReader,
-                        const std::shared_ptr<IGameStateProvider>& stateProvider,
-                        const std::shared_ptr<IGameEventAggregator>& eventAggregator );
+      GameInputHandler( const std::shared_ptr<IGameInputReader> inputReader,
+                        const std::shared_ptr<IGameStateProvider> stateProvider,
+                        const std::shared_ptr<IGameEventAggregator> eventAggregator );
 
       void AddInputHandlerForGameState( GameState state,
                                         std::shared_ptr<IGameInputHandler> inputHandler );
@@ -25,9 +25,9 @@ namespace ConsoleGame
       void HandleInput() override;
 
    private:
-      const std::shared_ptr<IGameInputReader>& _inputReader;
-      const std::shared_ptr<IGameStateProvider>& _stateProvider;
-      const std::shared_ptr<IGameEventAggregator>& _eventAggregator;
+      const std::shared_ptr<IGameInputReader> _inputReader;
+      const std::shared_ptr<IGameStateProvider> _stateProvider;
+      const std::shared_ptr<IGameEventAggregator> _eventAggregator;
 
       std::map<GameState, std::shared_ptr<IGameInputHandler>> _stateInputHandlers;
    };

--- a/ConsoleGame/GameRunner.cpp
+++ b/ConsoleGame/GameRunner.cpp
@@ -7,10 +7,10 @@
 
 using namespace ConsoleGame;
 
-GameRunner::GameRunner( const std::shared_ptr<IGameEventAggregator>& eventAggregator,
-                        const std::shared_ptr<IGameClock>& clock,
-                        const std::shared_ptr<IGameInputHandler>& inputHandler,
-                        const std::shared_ptr<IGameRenderer>& renderer )
+GameRunner::GameRunner( const std::shared_ptr<IGameEventAggregator> eventAggregator,
+                        const std::shared_ptr<IGameClock> clock,
+                        const std::shared_ptr<IGameInputHandler> inputHandler,
+                        const std::shared_ptr<IGameRenderer> renderer )
    : _clock( clock ),
      _inputHandler( inputHandler ),
      _renderer( renderer ),

--- a/ConsoleGame/GameRunner.h
+++ b/ConsoleGame/GameRunner.h
@@ -14,10 +14,10 @@ namespace ConsoleGame
    class GameRunner : public IGameRunner
    {
    public:
-      GameRunner( const std::shared_ptr<IGameEventAggregator>& eventAggregator,
-                  const std::shared_ptr<IGameClock>& clock,
-                  const std::shared_ptr<IGameInputHandler>& inputHandler,
-                  const std::shared_ptr<IGameRenderer>& renderer );
+      GameRunner( const std::shared_ptr<IGameEventAggregator> eventAggregator,
+                  const std::shared_ptr<IGameClock> clock,
+                  const std::shared_ptr<IGameInputHandler> inputHandler,
+                  const std::shared_ptr<IGameRenderer> renderer );
 
       void Run() override;
 
@@ -25,9 +25,9 @@ namespace ConsoleGame
       void HandleQuitEvent();
 
    private:
-      const std::shared_ptr<IGameClock>& _clock;
-      const std::shared_ptr<IGameInputHandler>& _inputHandler;
-      const std::shared_ptr<IGameRenderer>& _renderer;
+      const std::shared_ptr<IGameClock> _clock;
+      const std::shared_ptr<IGameInputHandler> _inputHandler;
+      const std::shared_ptr<IGameRenderer> _renderer;
 
       bool _isRunning;
    };

--- a/ConsoleGame/HighResolutionClockWrapper.cpp
+++ b/ConsoleGame/HighResolutionClockWrapper.cpp
@@ -1,0 +1,11 @@
+#include <chrono>
+
+#include "HighResolutionClockWrapper.h"
+
+using namespace std;
+using namespace ConsoleGame;
+
+long long HighResolutionClockWrapper::Now()
+{
+   return chrono::high_resolution_clock::now().time_since_epoch().count();
+}

--- a/ConsoleGame/HighResolutionClockWrapper.h
+++ b/ConsoleGame/HighResolutionClockWrapper.h
@@ -7,9 +7,6 @@ namespace ConsoleGame
    class HighResolutionClockWrapper : public IHighResolutionClock
    {
    public:
-      std::chrono::steady_clock::time_point Now() override
-      {
-         return std::chrono::high_resolution_clock::now();
-      }
+      long long Now() override;
    };
 }

--- a/ConsoleGame/HighResolutionClockWrapper.h
+++ b/ConsoleGame/HighResolutionClockWrapper.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "IHighResolutionClock.h"
+
+namespace ConsoleGame
+{
+   class HighResolutionClockWrapper : public IHighResolutionClock
+   {
+      std::chrono::steady_clock::time_point Now() override
+      {
+         return std::chrono::high_resolution_clock::now();
+      }
+   };
+}

--- a/ConsoleGame/HighResolutionClockWrapper.h
+++ b/ConsoleGame/HighResolutionClockWrapper.h
@@ -6,6 +6,7 @@ namespace ConsoleGame
 {
    class HighResolutionClockWrapper : public IHighResolutionClock
    {
+   public:
       std::chrono::steady_clock::time_point Now() override
       {
          return std::chrono::high_resolution_clock::now();

--- a/ConsoleGame/IHighResolutionClock.h
+++ b/ConsoleGame/IHighResolutionClock.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <chrono>
+
+namespace ConsoleGame
+{
+   class __declspec( novtable ) IHighResolutionClock
+   {
+   public:
+      virtual std::chrono::steady_clock::time_point Now() = 0;
+   };
+}

--- a/ConsoleGame/IHighResolutionClock.h
+++ b/ConsoleGame/IHighResolutionClock.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <chrono>
-
 namespace ConsoleGame
 {
    class __declspec( novtable ) IHighResolutionClock
    {
    public:
-      virtual std::chrono::steady_clock::time_point Now() = 0;
+      virtual long long Now() = 0;
    };
 }

--- a/ConsoleGame/IKeyboard.h
+++ b/ConsoleGame/IKeyboard.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace ConsoleGame
+{
+   enum class KeyCode;
+
+   class __declspec( novtable ) IKeyboard
+   {
+   public:
+      virtual bool IsKeyDown( KeyCode keyCode ) const = 0;
+   };
+}

--- a/ConsoleGame/ISleeper.h
+++ b/ConsoleGame/ISleeper.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace ConsoleGame
+{
+   class __declspec( novtable ) ISleeper
+   {
+   public:
+      virtual void Sleep( unsigned long milliseconds ) = 0;
+   };
+}

--- a/ConsoleGame/KeyboardInputReader.cpp
+++ b/ConsoleGame/KeyboardInputReader.cpp
@@ -9,7 +9,7 @@
 using namespace std;
 using namespace ConsoleGame;
 
-KeyboardInputReader::KeyboardInputReader( const shared_ptr<GameInputConfig>& inputConfig )
+KeyboardInputReader::KeyboardInputReader( const shared_ptr<GameInputConfig> inputConfig )
 {
    for ( int i = 0; i < (int)GameButton::GameButtonCount; i++ )
    {

--- a/ConsoleGame/KeyboardInputReader.cpp
+++ b/ConsoleGame/KeyboardInputReader.cpp
@@ -1,15 +1,15 @@
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-
 #include "KeyboardInputReader.h"
 #include "GameInputConfig.h"
+#include "IKeyboard.h"
 #include "KeyCode.h"
 #include "GameButton.h"
 
 using namespace std;
 using namespace ConsoleGame;
 
-KeyboardInputReader::KeyboardInputReader( const shared_ptr<GameInputConfig> inputConfig )
+KeyboardInputReader::KeyboardInputReader( const shared_ptr<GameInputConfig> inputConfig,
+                                          const shared_ptr<IKeyboard> keyboard )
+   : _keyboard( keyboard )
 {
    for ( int i = 0; i < (int)GameButton::GameButtonCount; i++ )
    {
@@ -40,7 +40,7 @@ void KeyboardInputReader::ReadInput()
 
       for ( auto keyCode : keyCodes )
       {
-         if ( IsKeyDown( keyCode ) )
+         if ( _keyboard->IsKeyDown( keyCode ) )
          {
             buttonIsDown = true;
             break;
@@ -83,9 +83,4 @@ bool KeyboardInputReader::WasAnyButtonPressed() const
    }
 
    return false;
-}
-
-bool KeyboardInputReader::IsKeyDown( KeyCode keyCode ) const
-{
-   return GetKeyState( (int)keyCode ) & 0x800; // if the high-order bit is 1, the key is down
 }

--- a/ConsoleGame/KeyboardInputReader.h
+++ b/ConsoleGame/KeyboardInputReader.h
@@ -21,7 +21,7 @@ namespace ConsoleGame
    class KeyboardInputReader : public IGameInputReader
    {
    public:
-      KeyboardInputReader( const std::shared_ptr<GameInputConfig>& inputConfig );
+      KeyboardInputReader( const std::shared_ptr<GameInputConfig> inputConfig );
 
       void ReadInput() override;
       bool WasButtonPressed( GameButton button ) const override;

--- a/ConsoleGame/KeyboardInputReader.h
+++ b/ConsoleGame/KeyboardInputReader.h
@@ -15,13 +15,15 @@ namespace ConsoleGame
    };
 
    class GameInputConfig;
+   class IKeyboard;
    enum class KeyCode;
    enum class GameButton;
 
    class KeyboardInputReader : public IGameInputReader
    {
    public:
-      KeyboardInputReader( const std::shared_ptr<GameInputConfig> inputConfig );
+      KeyboardInputReader( const std::shared_ptr<GameInputConfig> inputConfig,
+                           const std::shared_ptr<IKeyboard> keyboard );
 
       void ReadInput() override;
       bool WasButtonPressed( GameButton button ) const override;
@@ -29,9 +31,8 @@ namespace ConsoleGame
       bool WasAnyButtonPressed() const override;
 
    private:
-      bool IsKeyDown( KeyCode key ) const;
+      std::shared_ptr<IKeyboard> _keyboard;
 
-   private:
       std::map<GameButton, ButtonState> _buttonStates;
       std::map<GameButton, std::vector<KeyCode>> _buttonKeyBindings;
    };

--- a/ConsoleGame/KeyboardWrapper.cpp
+++ b/ConsoleGame/KeyboardWrapper.cpp
@@ -1,0 +1,12 @@
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include "KeyboardWrapper.h"
+#include "KeyCode.h"
+
+using namespace ConsoleGame;
+
+bool KeyboardWrapper::IsKeyDown( KeyCode keyCode ) const
+{
+   return GetKeyState( (int)keyCode ) & 0x800; // if the high-order bit is 1, the key is down
+}

--- a/ConsoleGame/KeyboardWrapper.h
+++ b/ConsoleGame/KeyboardWrapper.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "IKeyboard.h"
+
+namespace ConsoleGame
+{
+   class KeyboardWrapper : public IKeyboard
+   {
+   public:
+      bool IsKeyDown( KeyCode keyCode ) const override;
+   };
+}

--- a/ConsoleGame/PlayingStateConsoleRenderer.cpp
+++ b/ConsoleGame/PlayingStateConsoleRenderer.cpp
@@ -9,10 +9,10 @@
 using namespace std;
 using namespace ConsoleGame;
 
-PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<IConsoleDrawer>& consoleDrawer,
-                                                          const shared_ptr<GameRenderConfig>& renderConfig,
-                                                          const shared_ptr<GameConfig>& gameConfig,
-                                                          const shared_ptr<IPlayerInfoProvider>& playerInfoProvider )
+PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<IConsoleDrawer> consoleDrawer,
+                                                          const shared_ptr<GameRenderConfig> renderConfig,
+                                                          const shared_ptr<GameConfig> gameConfig,
+                                                          const shared_ptr<IPlayerInfoProvider> playerInfoProvider )
    : _consoleDrawer( consoleDrawer ),
      _renderConfig( renderConfig ),
      _gameConfig( gameConfig ),

--- a/ConsoleGame/PlayingStateConsoleRenderer.h
+++ b/ConsoleGame/PlayingStateConsoleRenderer.h
@@ -15,10 +15,10 @@ namespace ConsoleGame
    class PlayingStateConsoleRenderer : public IGameRenderer
    {
    public:
-      PlayingStateConsoleRenderer( const std::shared_ptr<IConsoleDrawer>& consoleDrawer,
-                                   const std::shared_ptr<GameRenderConfig>& renderConfig,
-                                   const std::shared_ptr<GameConfig>& gameConfig,
-                                   const std::shared_ptr<IPlayerInfoProvider>& playerInfoProvider );
+      PlayingStateConsoleRenderer( const std::shared_ptr<IConsoleDrawer> consoleDrawer,
+                                   const std::shared_ptr<GameRenderConfig> renderConfig,
+                                   const std::shared_ptr<GameConfig> gameConfig,
+                                   const std::shared_ptr<IPlayerInfoProvider> playerInfoProvider );
 
       void Render() override;
 
@@ -27,9 +27,9 @@ namespace ConsoleGame
       char GetPlayerCharFromDirection( Direction direction );
 
    private:
-      const std::shared_ptr<IConsoleDrawer>& _consoleDrawer;
-      const std::shared_ptr<GameRenderConfig>& _renderConfig;
-      const std::shared_ptr<GameConfig>& _gameConfig;
-      const std::shared_ptr<IPlayerInfoProvider>& _playerInfoProvider;
+      const std::shared_ptr<IConsoleDrawer> _consoleDrawer;
+      const std::shared_ptr<GameRenderConfig> _renderConfig;
+      const std::shared_ptr<GameConfig> _gameConfig;
+      const std::shared_ptr<IPlayerInfoProvider> _playerInfoProvider;
    };
 }

--- a/ConsoleGame/PlayingStateInputHandler.cpp
+++ b/ConsoleGame/PlayingStateInputHandler.cpp
@@ -7,8 +7,8 @@
 using namespace std;
 using namespace ConsoleGame;
 
-PlayingStateInputHandler::PlayingStateInputHandler( const shared_ptr<IGameInputReader>& inputReader,
-                                                    const shared_ptr<IGameCommandExecutor>& commandExecutor )
+PlayingStateInputHandler::PlayingStateInputHandler( const shared_ptr<IGameInputReader> inputReader,
+                                                    const shared_ptr<IGameCommandExecutor> commandExecutor )
    : _inputReader( inputReader ),
      _commandExecutor( commandExecutor )
 {

--- a/ConsoleGame/PlayingStateInputHandler.h
+++ b/ConsoleGame/PlayingStateInputHandler.h
@@ -12,13 +12,13 @@ namespace ConsoleGame
    class PlayingStateInputHandler : public IGameInputHandler
    {
    public:
-      PlayingStateInputHandler( const std::shared_ptr<IGameInputReader>& inputReader,
-                                const std::shared_ptr<IGameCommandExecutor>& commandExecutor );
+      PlayingStateInputHandler( const std::shared_ptr<IGameInputReader> inputReader,
+                                const std::shared_ptr<IGameCommandExecutor> commandExecutor );
 
       void HandleInput() override;
 
    private:
-      const std::shared_ptr<IGameInputReader>& _inputReader;
-      const std::shared_ptr<IGameCommandExecutor>& _commandExecutor;
+      const std::shared_ptr<IGameInputReader> _inputReader;
+      const std::shared_ptr<IGameCommandExecutor> _commandExecutor;
    };
 }

--- a/ConsoleGame/SleeperWrapper.cpp
+++ b/ConsoleGame/SleeperWrapper.cpp
@@ -1,0 +1,11 @@
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include "SleeperWrapper.h"
+
+using namespace ConsoleGame;
+
+void SleeperWrapper::Sleep( unsigned long milliseconds )
+{
+   Sleep( milliseconds );
+}

--- a/ConsoleGame/SleeperWrapper.cpp
+++ b/ConsoleGame/SleeperWrapper.cpp
@@ -7,5 +7,5 @@ using namespace ConsoleGame;
 
 void SleeperWrapper::Sleep( unsigned long milliseconds )
 {
-   Sleep( milliseconds );
+   ::Sleep( milliseconds );
 }

--- a/ConsoleGame/SleeperWrapper.h
+++ b/ConsoleGame/SleeperWrapper.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "ISleeper.h"
+
+namespace ConsoleGame
+{
+   class SleeperWrapper : ISleeper
+   {
+   public:
+      void Sleep( unsigned long milliseconds ) override;
+   };
+}

--- a/ConsoleGame/SleeperWrapper.h
+++ b/ConsoleGame/SleeperWrapper.h
@@ -4,7 +4,7 @@
 
 namespace ConsoleGame
 {
-   class SleeperWrapper : ISleeper
+   class SleeperWrapper : public ISleeper
    {
    public:
       void Sleep( unsigned long milliseconds ) override;

--- a/ConsoleGame/StartupStateConsoleRenderer.cpp
+++ b/ConsoleGame/StartupStateConsoleRenderer.cpp
@@ -10,9 +10,9 @@
 using namespace std;
 using namespace ConsoleGame;
 
-StartupStateConsoleRenderer::StartupStateConsoleRenderer( const shared_ptr<IConsoleDrawer>& consoleDrawer,
-                                                          const shared_ptr<GameRenderConfig>& renderConfig,
-                                                          const shared_ptr<GameInputConfig>& inputConfig )
+StartupStateConsoleRenderer::StartupStateConsoleRenderer( const shared_ptr<IConsoleDrawer> consoleDrawer,
+                                                          const shared_ptr<GameRenderConfig> renderConfig,
+                                                          const shared_ptr<GameInputConfig> inputConfig )
    : _consoleDrawer( consoleDrawer ),
      _renderConfig( renderConfig ),
      _inputConfig( inputConfig )

--- a/ConsoleGame/StartupStateConsoleRenderer.h
+++ b/ConsoleGame/StartupStateConsoleRenderer.h
@@ -13,9 +13,9 @@ namespace ConsoleGame
    class StartupStateConsoleRenderer : public IGameRenderer
    {
    public:
-      StartupStateConsoleRenderer( const std::shared_ptr<IConsoleDrawer>& consoleDrawer,
-                                   const std::shared_ptr<GameRenderConfig>& renderConfig,
-                                   const std::shared_ptr<GameInputConfig>& inputConfig );
+      StartupStateConsoleRenderer( const std::shared_ptr<IConsoleDrawer> consoleDrawer,
+                                   const std::shared_ptr<GameRenderConfig> renderConfig,
+                                   const std::shared_ptr<GameInputConfig> inputConfig );
 
       void Render() override;
 
@@ -23,8 +23,8 @@ namespace ConsoleGame
       void DrawKeyBindings( int middleX, int top ) const;
 
    private:
-      const std::shared_ptr<IConsoleDrawer>& _consoleDrawer;
-      const std::shared_ptr<GameRenderConfig>& _renderConfig;
-      const std::shared_ptr<GameInputConfig>& _inputConfig;
+      const std::shared_ptr<IConsoleDrawer> _consoleDrawer;
+      const std::shared_ptr<GameRenderConfig> _renderConfig;
+      const std::shared_ptr<GameInputConfig> _inputConfig;
    };
 }

--- a/ConsoleGame/StartupStateInputHandler.cpp
+++ b/ConsoleGame/StartupStateInputHandler.cpp
@@ -6,8 +6,8 @@
 using namespace std;
 using namespace ConsoleGame;
 
-StartupStateInputHandler::StartupStateInputHandler( const shared_ptr<IGameInputReader>& inputReader,
-                                                    const shared_ptr<IGameCommandExecutor>& commandExecutor )
+StartupStateInputHandler::StartupStateInputHandler( const shared_ptr<IGameInputReader> inputReader,
+                                                    const shared_ptr<IGameCommandExecutor> commandExecutor )
    : _inputReader( inputReader ),
      _commandExecutor( commandExecutor )
 {

--- a/ConsoleGame/StartupStateInputHandler.h
+++ b/ConsoleGame/StartupStateInputHandler.h
@@ -12,13 +12,13 @@ namespace ConsoleGame
    class StartupStateInputHandler : public IGameInputHandler
    {
    public:
-      StartupStateInputHandler( const std::shared_ptr<IGameInputReader>& inputReader,
-                                const std::shared_ptr<IGameCommandExecutor>& commandExecutor );
+      StartupStateInputHandler( const std::shared_ptr<IGameInputReader> inputReader,
+                                const std::shared_ptr<IGameCommandExecutor> commandExecutor );
 
       void HandleInput() override;
 
    private:
-      const std::shared_ptr<IGameInputReader>& _inputReader;
-      const std::shared_ptr<IGameCommandExecutor>& _commandExecutor;
+      const std::shared_ptr<IGameInputReader> _inputReader;
+      const std::shared_ptr<IGameCommandExecutor> _commandExecutor;
    };
 }

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -40,6 +40,8 @@
     <ClInclude Include="mock_GameInputHandler.h" />
     <ClInclude Include="mock_GameInputReader.h" />
     <ClInclude Include="mock_GameStateProvider.h" />
+    <ClInclude Include="mock_HighResolutionClock.h" />
+    <ClInclude Include="mock_Sleeper.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="GameInputHandlerTests.cpp" />

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -50,6 +50,7 @@
     <ClCompile Include="GameInputHandlerTests.cpp" />
     <ClCompile Include="GameTests.cpp" />
     <ClCompile Include="KeyboardInputReaderTests.cpp" />
+    <ClCompile Include="PlayingStateInputHandlerTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ConsoleGame\ConsoleGame.vcxproj">

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h" />
     <ClInclude Include="mock_GameInputReader.h" />
+    <ClInclude Include="mock_GameStateProvider.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="GameTests.cpp" />

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -48,6 +48,7 @@
     <ClCompile Include="GameClockTests.cpp" />
     <ClCompile Include="GameInputHandlerTests.cpp" />
     <ClCompile Include="GameTests.cpp" />
+    <ClCompile Include="KeyboardInputReaderTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ConsoleGame\ConsoleGame.vcxproj">

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -37,6 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h" />
+    <ClInclude Include="mock_GameInputReader.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="GameTests.cpp" />

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -36,6 +36,7 @@
     <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
   </PropertyGroup>
   <ItemGroup>
+    <ClInclude Include="mock_GameCommandExecutor.h" />
     <ClInclude Include="mock_GameEventAggregator.h" />
     <ClInclude Include="mock_GameInputHandler.h" />
     <ClInclude Include="mock_GameInputReader.h" />

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -41,6 +41,7 @@
     <ClInclude Include="mock_GameInputReader.h" />
     <ClInclude Include="mock_GameStateProvider.h" />
     <ClInclude Include="mock_HighResolutionClock.h" />
+    <ClInclude Include="mock_Keyboard.h" />
     <ClInclude Include="mock_Sleeper.h" />
   </ItemGroup>
   <ItemGroup>

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -32,17 +32,14 @@
   <ImportGroup Label="Shared" />
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
+  </PropertyGroup>
   <ItemGroup>
-    <ClInclude Include="pch.h" />
+    <ClInclude Include="mock_GameEventAggregator.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="test.cpp" />
-    <ClCompile Include="pch.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
-    </ClCompile>
+    <ClCompile Include="GameTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ConsoleGame\ConsoleGame.vcxproj">
@@ -56,6 +53,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+    <Import Project="..\packages\gmock.v1.8.1.8.1\build\native\gmock.v1.8.targets" Condition="Exists('..\packages\gmock.v1.8.1.8.1\build\native\gmock.v1.8.targets')" />
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -74,18 +72,31 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>$(solutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>%(AdditionalDependencies);"$(solutionDir)ConsoleGameTests\x64\Debug\ConsoleGame.lib"</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <PreLinkEvent>
+      <Command>lib /NOLOGO /OUT:"$(solutionDir)ConsoleGameTests\x64\Debug\ConsoleGame.lib" "$(solutionDir)ConsoleGame\x64\Debug\*.obj</Command>
+    </PreLinkEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -105,24 +116,30 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(solutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <AdditionalDependencies>%(AdditionalDependencies);"$(solutionDir)ConsoleGameTests\x64\Release\ConsoleGame.lib"</AdditionalDependencies>
     </Link>
+    <PreLinkEvent>
+      <Command>lib /NOLOGO /OUT:"$(solutionDir)ConsoleGameTests\x64\Release\ConsoleGame.lib" "$(solutionDir)ConsoleGame\x64\Release\*.obj</Command>
+    </PreLinkEvent>
   </ItemDefinitionGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\gmock.v1.8.1.8.1\build\native\gmock.v1.8.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\gmock.v1.8.1.8.1\build\native\gmock.v1.8.targets'))" />
   </Target>
 </Project>

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -44,6 +44,7 @@
     <ClInclude Include="mock_Sleeper.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="GameClockTests.cpp" />
     <ClCompile Include="GameInputHandlerTests.cpp" />
     <ClCompile Include="GameTests.cpp" />
   </ItemGroup>

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -51,6 +51,7 @@
     <ClCompile Include="GameTests.cpp" />
     <ClCompile Include="KeyboardInputReaderTests.cpp" />
     <ClCompile Include="PlayingStateInputHandlerTests.cpp" />
+    <ClCompile Include="StartupStateInputHandlerTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ConsoleGame\ConsoleGame.vcxproj">

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{4076dd39-2990-436a-a91f-cb6cb9b0799b}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="test.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ConsoleGame\ConsoleGame.vcxproj">
+      <Project>{f1e9b035-58db-4e2a-9400-a9ff4d73da01}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemDefinitionGroup />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+  </ImportGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+  </Target>
+</Project>

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -37,10 +37,12 @@
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h" />
+    <ClInclude Include="mock_GameInputHandler.h" />
     <ClInclude Include="mock_GameInputReader.h" />
     <ClInclude Include="mock_GameStateProvider.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="GameInputHandlerTests.cpp" />
     <ClCompile Include="GameTests.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -9,6 +9,9 @@
     <ClInclude Include="mock_GameEventAggregator.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="mock_GameInputReader.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="GameTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="mock_GameEventAggregator.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Mocks">
+      <UniqueIdentifier>{a125ac42-bdf3-4553-a036-5b08f971d7d1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Tests">
+      <UniqueIdentifier>{13933dfa-aac8-49da-a1ea-e0c8b889f9d7}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -21,6 +21,12 @@
     <ClInclude Include="mock_GameInputHandler.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="mock_HighResolutionClock.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
+    <ClInclude Include="mock_Sleeper.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -16,6 +16,9 @@
     <ClCompile Include="PlayingStateInputHandlerTests.cpp">
       <Filter>Tests\Input</Filter>
     </ClCompile>
+    <ClCompile Include="StartupStateInputHandlerTests.cpp">
+      <Filter>Tests\Input</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -4,6 +4,9 @@
     <ClCompile Include="GameTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="GameInputHandlerTests.cpp">
+      <Filter>Tests\Input</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">
@@ -15,6 +18,9 @@
     <ClInclude Include="mock_GameInputReader.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="mock_GameInputHandler.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">
@@ -22,6 +28,9 @@
     </Filter>
     <Filter Include="Tests">
       <UniqueIdentifier>{13933dfa-aac8-49da-a1ea-e0c8b889f9d7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Tests\Input">
+      <UniqueIdentifier>{700158eb-2489-40b4-b065-d241c20a0716}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -9,6 +9,9 @@
     <ClInclude Include="mock_GameEventAggregator.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="mock_GameStateProvider.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
     <ClInclude Include="mock_GameInputReader.h">
       <Filter>Mocks</Filter>
     </ClInclude>

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -7,6 +7,9 @@
     <ClCompile Include="GameInputHandlerTests.cpp">
       <Filter>Tests\Input</Filter>
     </ClCompile>
+    <ClCompile Include="GameClockTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -10,6 +10,9 @@
     <ClCompile Include="GameClockTests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="KeyboardInputReaderTests.cpp">
+      <Filter>Tests\Input</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -13,6 +13,9 @@
     <ClCompile Include="KeyboardInputReaderTests.cpp">
       <Filter>Tests\Input</Filter>
     </ClCompile>
+    <ClCompile Include="PlayingStateInputHandlerTests.cpp">
+      <Filter>Tests\Input</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="mock_Sleeper.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="mock_Keyboard.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClInclude Include="mock_Keyboard.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="mock_GameCommandExecutor.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/ConsoleGameTests/GameClockTests.cpp
+++ b/ConsoleGameTests/GameClockTests.cpp
@@ -24,7 +24,7 @@ public:
                                        _sleeperMock,
                                        _framesPerSecond ) );
 
-      ON_CALL( *_highResolutionClockMock, Now() ).WillByDefault( Return( chrono::steady_clock::time_point() ) );
+      ON_CALL( *_highResolutionClockMock, Now() ).WillByDefault( Return( 0ll ) );
    }
 
 protected:

--- a/ConsoleGameTests/GameClockTests.cpp
+++ b/ConsoleGameTests/GameClockTests.cpp
@@ -41,3 +41,81 @@ TEST_F( GameClockTests, Constructor_Always_InitializesAllValues )
    EXPECT_EQ( _gameClock->GetTotalFrameCount(), 0 );
    EXPECT_EQ( _gameClock->GetLagFrameCount(), 0 );
 }
+
+TEST_F( GameClockTests, Start_AlreadyRunning_DoesNotChangeValues )
+{
+   EXPECT_CALL( *_highResolutionClockMock, Now() ).Times( 1 );
+
+   _gameClock->Start();
+   _gameClock->Start();
+}
+
+TEST_F( GameClockTests, Start_AfterPreviousRun_ResetsAllValues )
+{
+   EXPECT_CALL( *_highResolutionClockMock, Now() );
+
+   _gameClock->Start();
+
+   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( 1'000'000ll ) );
+   EXPECT_CALL( *_sleeperMock, Sleep( _ ) );
+
+   _gameClock->Tick();
+   _gameClock->Stop();
+
+   EXPECT_CALL( *_highResolutionClockMock, Now() );
+
+   _gameClock->Start();
+
+   EXPECT_EQ( _gameClock->GetFramesPerSecond(), 100 );
+   EXPECT_EQ( _gameClock->GetTotalFrameCount(), 0 );
+   EXPECT_EQ( _gameClock->GetLagFrameCount(), 0 );
+}
+
+TEST_F( GameClockTests, Tick_NotRunning_DoesNothing )
+{
+   EXPECT_CALL( *_highResolutionClockMock, Now() ).Times( 0 );
+
+   _gameClock->Tick();
+}
+
+TEST_F( GameClockTests, Tick_FrameIsCounted_IncrementsTotalFrames )
+{
+   EXPECT_CALL( *_highResolutionClockMock, Now() );
+
+   _gameClock->Start();
+
+   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( 1ll ) );
+   EXPECT_CALL( *_sleeperMock, Sleep( _ ) );
+
+   _gameClock->Tick();
+
+   EXPECT_EQ( _gameClock->GetTotalFrameCount(), 1 );
+}
+
+TEST_F( GameClockTests, Tick_TimeIsLeftInFrame_SleepsForRemainingTime )
+{
+   EXPECT_CALL( *_highResolutionClockMock, Now() );
+
+   _gameClock->Start();
+
+   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( 1'000'000ll ) );
+   EXPECT_CALL( *_sleeperMock, Sleep( 9 ) );
+
+   _gameClock->Tick();
+}
+
+TEST_F( GameClockTests, Tick_FrameIsOverTime_IncrementsLagFrames )
+{
+   EXPECT_CALL( *_highResolutionClockMock, Now() );
+
+   _gameClock->Start();
+
+   auto nanoSecondsPerFrame = 1'000'000'000ll / _framesPerSecond;
+
+   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( nanoSecondsPerFrame + 1ll ) );
+   EXPECT_CALL( *_sleeperMock, Sleep( _ ) ).Times( 0 );
+
+   _gameClock->Tick();
+
+   EXPECT_EQ( _gameClock->GetLagFrameCount(), 1 );
+}

--- a/ConsoleGameTests/GameClockTests.cpp
+++ b/ConsoleGameTests/GameClockTests.cpp
@@ -1,0 +1,43 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <ConsoleGame/GameClock.h>
+
+#include "mock_HighResolutionClock.h"
+#include "mock_Sleeper.h"
+
+using namespace std;
+using namespace testing;
+using namespace ConsoleGame;
+
+class GameClockTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _highResolutionClockMock.reset( new mock_HighResolutionClock() );
+      _sleeperMock.reset( new mock_Sleeper() );
+      _framesPerSecond = 100;
+
+      _gameClock.reset( new GameClock( _highResolutionClockMock,
+                                       _sleeperMock,
+                                       _framesPerSecond ) );
+
+      ON_CALL( *_highResolutionClockMock, Now() ).WillByDefault( Return( chrono::steady_clock::time_point() ) );
+   }
+
+protected:
+   shared_ptr<mock_HighResolutionClock> _highResolutionClockMock;
+   shared_ptr<mock_Sleeper> _sleeperMock;
+   int _framesPerSecond;
+
+   shared_ptr<GameClock> _gameClock;
+};
+
+TEST_F( GameClockTests, Constructor_Always_InitializesAllValues )
+{
+   EXPECT_EQ( _gameClock->GetFramesPerSecond(), 100 );
+   EXPECT_EQ( _gameClock->GetTotalFrameCount(), 0 );
+   EXPECT_EQ( _gameClock->GetLagFrameCount(), 0 );
+}

--- a/ConsoleGameTests/GameInputHandlerTests.cpp
+++ b/ConsoleGameTests/GameInputHandlerTests.cpp
@@ -1,0 +1,90 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <ConsoleGame/GameInputHandler.h>
+#include <ConsoleGame/GameState.h>
+#include <ConsoleGame/GameButton.h>
+#include <ConsoleGame/GameEvent.h>
+
+#include "mock_GameInputReader.h"
+#include "mock_GameStateProvider.h"
+#include "mock_GameEventAggregator.h"
+#include "mock_GameInputHandler.h"
+
+using namespace std;
+using namespace testing;
+using namespace ConsoleGame;
+
+class GameInputHandlerTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _inputReaderMock.reset( new mock_GameInputReader() );
+      _stateProviderMock.reset( new mock_GameStateProvider );
+      _eventAggregatorMock.reset( new mock_GameEventAggregator );
+      _startupInputHandler.reset( new mock_GameInputHandler );
+
+      _inputHandler.reset( new GameInputHandler( _inputReaderMock,
+                                                 _stateProviderMock,
+                                                 _eventAggregatorMock ) );
+
+      _inputHandler->AddInputHandlerForGameState( GameState::Startup, _startupInputHandler );
+
+      ON_CALL( *_stateProviderMock, GetGameState() ).WillByDefault( Return( GameState::Startup ) );
+      ON_CALL( *_inputReaderMock, WasButtonPressed( _ ) ).WillByDefault( Return( false ) );
+   }
+
+   void TearDown() override
+   { }
+
+protected:
+   shared_ptr<mock_GameInputReader> _inputReaderMock;
+   shared_ptr<mock_GameStateProvider> _stateProviderMock;
+   shared_ptr<mock_GameEventAggregator> _eventAggregatorMock;
+   shared_ptr<mock_GameInputHandler> _startupInputHandler;
+
+   shared_ptr<GameInputHandler> _inputHandler;
+};
+
+TEST_F( GameInputHandlerTests, HandleInput_Always_ReadsInputAndHandlesIt )
+{
+   EXPECT_CALL( *_inputReaderMock, ReadInput() );
+   EXPECT_CALL( *_inputReaderMock, WasButtonPressed( GameButton::Diagnostics ) );
+   EXPECT_CALL( *_stateProviderMock, GetGameState() );
+   EXPECT_CALL( *_startupInputHandler, HandleInput() );
+
+   _inputHandler->HandleInput();
+}
+
+TEST_F( GameInputHandlerTests, HandleInput_DiagnosticsButtonWasNotPressed_DoesNotRaiseAnyEvents )
+{
+   EXPECT_CALL( *_inputReaderMock, ReadInput() );
+   EXPECT_CALL( *_inputReaderMock, WasButtonPressed( GameButton::Diagnostics ) );
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( _ ) ).Times( 0 );
+   EXPECT_CALL( *_stateProviderMock, GetGameState() );
+   EXPECT_CALL( *_startupInputHandler, HandleInput() );
+
+   _inputHandler->HandleInput();
+}
+
+TEST_F( GameInputHandlerTests, HandleInput_DiagnosticsButtonWasPressed_RaisesToggleDiagnosticsEvent )
+{
+   EXPECT_CALL( *_inputReaderMock, ReadInput() );
+   EXPECT_CALL( *_inputReaderMock, WasButtonPressed( GameButton::Diagnostics ) ).WillRepeatedly ( Return( true ) );
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ToggleDiagnostics ) ).Times( 1 );
+   EXPECT_CALL( *_stateProviderMock, GetGameState() );
+   EXPECT_CALL( *_startupInputHandler, HandleInput() );
+
+   _inputHandler->HandleInput();
+}
+
+TEST_F( GameInputHandlerTests, HandleInput_InputHandlerNotFoundForState_ThrowsException )
+{
+   EXPECT_CALL( *_inputReaderMock, ReadInput() );
+   EXPECT_CALL( *_inputReaderMock, WasButtonPressed( GameButton::Diagnostics ) );
+   EXPECT_CALL( *_stateProviderMock, GetGameState() ).WillRepeatedly( Return( GameState::Playing ) );
+
+   EXPECT_THROW( _inputHandler->HandleInput(), std::out_of_range );
+}

--- a/ConsoleGameTests/GameInputHandlerTests.cpp
+++ b/ConsoleGameTests/GameInputHandlerTests.cpp
@@ -36,9 +36,6 @@ public:
       ON_CALL( *_inputReaderMock, WasButtonPressed( _ ) ).WillByDefault( Return( false ) );
    }
 
-   void TearDown() override
-   { }
-
 protected:
    shared_ptr<mock_GameInputReader> _inputReaderMock;
    shared_ptr<mock_GameStateProvider> _stateProviderMock;

--- a/ConsoleGameTests/GameTests.cpp
+++ b/ConsoleGameTests/GameTests.cpp
@@ -11,17 +11,35 @@
 
 #include "mock_GameEventAggregator.h"
 
+using namespace std;
+using namespace testing;
 using namespace ConsoleGame;
 
-TEST( Game, Constructor_Always_SetsGameStateToStartup )
+class GameTests : public Test
 {
-   auto game = std::shared_ptr<Game>( new Game( std::make_shared<GameConfig>(),
-                                                std::make_shared<mock_GameEventAggregator>() ) );
+public:
+   void SetUp() override
+   {
+      _config.reset( new GameConfig() );
+      _eventAggregatorMock.reset( new mock_GameEventAggregator() );
 
-   EXPECT_EQ( game->GetGameState(), GameState::Startup );
+      _game.reset( new Game( _config,
+                             _eventAggregatorMock ) );
+   }
+
+protected:
+   shared_ptr<GameConfig> _config;
+   shared_ptr<mock_GameEventAggregator> _eventAggregatorMock;
+
+   shared_ptr<Game> _game;
+};
+
+TEST_F( GameTests, Constructor_Always_SetsGameStateToStartup )
+{
+   EXPECT_EQ( _game->GetGameState(), GameState::Startup );
 }
 
-TEST( Game, Constructor_Always_SetsPlayerInfoBasedOnConfig )
+TEST_F( GameTests, Constructor_Always_SetsPlayerInfoBasedOnConfig )
 {
    auto config = std::make_shared<GameConfig>();
    config->PlayerStartDirection = Direction::Down;
@@ -36,29 +54,21 @@ TEST( Game, Constructor_Always_SetsPlayerInfoBasedOnConfig )
    EXPECT_EQ( game->GetPlayerYPosition(), 20 );
 }
 
-TEST( Game, ExecuteCommand_Start_SetsGameStateToPlaying )
+TEST_F( GameTests, ExecuteCommand_Start_SetsGameStateToPlaying )
 {
-   auto game = std::shared_ptr<Game>( new Game( std::make_shared<GameConfig>(),
-                                                std::make_shared<mock_GameEventAggregator>() ) );
+   _game->ExecuteCommand( GameCommand::Start );
 
-   game->ExecuteCommand( GameCommand::Start );
-
-   EXPECT_EQ( game->GetGameState(), GameState::Playing );
+   EXPECT_EQ( _game->GetGameState(), GameState::Playing );
 }
 
-TEST( Game, ExecuteCommand_Quit_RaisesShutdownEvent )
+TEST_F( GameTests, ExecuteCommand_Quit_RaisesShutdownEvent )
 {
-   auto eventAggregatorMock = std::make_shared<mock_GameEventAggregator>();
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::Shutdown ) ).Times( 1 );
 
-   auto game = std::shared_ptr<Game>( new Game( std::make_shared<GameConfig>(),
-                                                eventAggregatorMock ) );
-
-   EXPECT_CALL( *eventAggregatorMock, RaiseEvent( GameEvent::Shutdown ) ).Times( 1 );
-
-   game->ExecuteCommand( GameCommand::Quit );
+   _game->ExecuteCommand( GameCommand::Quit );
 }
 
-TEST( Game, ExecuteCommand_MovePlayerLeftWithinArenaBounds_UpdatesPlayerInfo )
+TEST_F( GameTests, ExecuteCommand_MovePlayerLeftWithinArenaBounds_UpdatesPlayerInfo )
 {
    auto config = std::make_shared<GameConfig>();
    config->ArenaWidth = 50;
@@ -77,7 +87,7 @@ TEST( Game, ExecuteCommand_MovePlayerLeftWithinArenaBounds_UpdatesPlayerInfo )
    EXPECT_EQ( game->GetPlayerYPosition(), 20 );
 }
 
-TEST( Game, ExecuteCommand_MovePlayerUpWithinArenaBounds_UpdatesPlayerInfo )
+TEST_F( GameTests, ExecuteCommand_MovePlayerUpWithinArenaBounds_UpdatesPlayerInfo )
 {
    auto config = std::make_shared<GameConfig>();
    config->PlayerStartDirection = Direction::Down;
@@ -96,7 +106,7 @@ TEST( Game, ExecuteCommand_MovePlayerUpWithinArenaBounds_UpdatesPlayerInfo )
    EXPECT_EQ( game->GetPlayerYPosition(), 19 );
 }
 
-TEST( Game, ExecuteCommand_MovePlayerRightaWithinArenaBounds_UpdatesPlayerInfo )
+TEST_F( GameTests, ExecuteCommand_MovePlayerRightaWithinArenaBounds_UpdatesPlayerInfo )
 {
    auto config = std::make_shared<GameConfig>();
    config->ArenaWidth = 50;
@@ -115,7 +125,7 @@ TEST( Game, ExecuteCommand_MovePlayerRightaWithinArenaBounds_UpdatesPlayerInfo )
    EXPECT_EQ( game->GetPlayerYPosition(), 20 );
 }
 
-TEST( Game, ExecuteCommand_MovePlayerDownWithinArenaBounds_UpdatesPlayerInfo )
+TEST_F( GameTests, ExecuteCommand_MovePlayerDownWithinArenaBounds_UpdatesPlayerInfo )
 {
    auto config = std::make_shared<GameConfig>();
    config->ArenaWidth = 50;
@@ -134,7 +144,7 @@ TEST( Game, ExecuteCommand_MovePlayerDownWithinArenaBounds_UpdatesPlayerInfo )
    EXPECT_EQ( game->GetPlayerYPosition(), 21 );
 }
 
-TEST( Game, ExecuteCommand_MovePlayerLeftOutsideArenaBounds_DoesNotUpdatePlayerPosition )
+TEST_F( GameTests, ExecuteCommand_MovePlayerLeftOutsideArenaBounds_DoesNotUpdatePlayerPosition )
 {
    auto config = std::make_shared<GameConfig>();
    config->ArenaWidth = 50;
@@ -153,7 +163,7 @@ TEST( Game, ExecuteCommand_MovePlayerLeftOutsideArenaBounds_DoesNotUpdatePlayerP
    EXPECT_EQ( game->GetPlayerYPosition(), 20 );
 }
 
-TEST( Game, ExecuteCommand_MovePlayerUpOutsideArenaBounds_DoesNotUpdatePlayerPosition )
+TEST_F( GameTests, ExecuteCommand_MovePlayerUpOutsideArenaBounds_DoesNotUpdatePlayerPosition )
 {
    auto config = std::make_shared<GameConfig>();
    config->ArenaWidth = 50;
@@ -172,7 +182,7 @@ TEST( Game, ExecuteCommand_MovePlayerUpOutsideArenaBounds_DoesNotUpdatePlayerPos
    EXPECT_EQ( game->GetPlayerYPosition(), 0 );
 }
 
-TEST( Game, ExecuteCommand_MovePlayerRightOutsideArenaBounds_DoesNotUpdatePlayerPosition )
+TEST_F( GameTests, ExecuteCommand_MovePlayerRightOutsideArenaBounds_DoesNotUpdatePlayerPosition )
 {
    auto config = std::make_shared<GameConfig>();
    config->ArenaWidth = 50;
@@ -191,7 +201,7 @@ TEST( Game, ExecuteCommand_MovePlayerRightOutsideArenaBounds_DoesNotUpdatePlayer
    EXPECT_EQ( game->GetPlayerYPosition(), 20 );
 }
 
-TEST( Game, ExecuteCommand_MovePlayerDownOutsideArenaBounds_DoesNotUpdatePlayerPosition )
+TEST_F( GameTests, ExecuteCommand_MovePlayerDownOutsideArenaBounds_DoesNotUpdatePlayerPosition )
 {
    auto config = std::make_shared<GameConfig>();
    config->ArenaWidth = 50;

--- a/ConsoleGameTests/GameTests.cpp
+++ b/ConsoleGameTests/GameTests.cpp
@@ -1,0 +1,21 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <ConsoleGame/Game.h>
+#include <ConsoleGame/GameConfig.h>
+#include <ConsoleGame/GameState.h>
+
+#include "mock_GameEventAggregator.h"
+
+using namespace ConsoleGame;
+
+TEST( Game, Constructor_DefaultGameState_IsStartup )
+{
+   auto eventAggregatorMock = std::make_shared<mock_GameEventAggregator>();
+
+   auto game = std::shared_ptr<Game>( new Game( std::make_shared<GameConfig>(),
+                                                eventAggregatorMock ) );
+
+   EXPECT_EQ( game->GetGameState(), GameState::Startup );
+}

--- a/ConsoleGameTests/GameTests.cpp
+++ b/ConsoleGameTests/GameTests.cpp
@@ -5,17 +5,207 @@
 #include <ConsoleGame/Game.h>
 #include <ConsoleGame/GameConfig.h>
 #include <ConsoleGame/GameState.h>
+#include <ConsoleGame/Direction.h>
+#include <ConsoleGame/GameCommand.h>
+#include <ConsoleGame/GameEvent.h>
 
 #include "mock_GameEventAggregator.h"
 
 using namespace ConsoleGame;
 
-TEST( Game, Constructor_DefaultGameState_IsStartup )
+TEST( Game, Constructor_Always_SetsGameStateToStartup )
+{
+   auto game = std::shared_ptr<Game>( new Game( std::make_shared<GameConfig>(),
+                                                std::make_shared<mock_GameEventAggregator>() ) );
+
+   EXPECT_EQ( game->GetGameState(), GameState::Startup );
+}
+
+TEST( Game, Constructor_Always_SetsPlayerInfoBasedOnConfig )
+{
+   auto config = std::make_shared<GameConfig>();
+   config->PlayerStartDirection = Direction::Down;
+   config->PlayerStartX = 10;
+   config->PlayerStartY = 20;
+
+   auto game = std::shared_ptr<Game>( new Game( config,
+                                                std::make_shared<mock_GameEventAggregator>() ) );
+
+   EXPECT_EQ( game->GetPlayerDirection(), Direction::Down );
+   EXPECT_EQ( game->GetPlayerXPosition(), 10 );
+   EXPECT_EQ( game->GetPlayerYPosition(), 20 );
+}
+
+TEST( Game, ExecuteCommand_Start_SetsGameStateToPlaying )
+{
+   auto game = std::shared_ptr<Game>( new Game( std::make_shared<GameConfig>(),
+                                                std::make_shared<mock_GameEventAggregator>() ) );
+
+   game->ExecuteCommand( GameCommand::Start );
+
+   EXPECT_EQ( game->GetGameState(), GameState::Playing );
+}
+
+TEST( Game, ExecuteCommand_Quit_RaisesShutdownEvent )
 {
    auto eventAggregatorMock = std::make_shared<mock_GameEventAggregator>();
 
    auto game = std::shared_ptr<Game>( new Game( std::make_shared<GameConfig>(),
                                                 eventAggregatorMock ) );
 
-   EXPECT_EQ( game->GetGameState(), GameState::Startup );
+   EXPECT_CALL( *eventAggregatorMock, RaiseEvent( GameEvent::Shutdown ) ).Times( 1 );
+
+   game->ExecuteCommand( GameCommand::Quit );
+}
+
+TEST( Game, ExecuteCommand_MovePlayerLeftWithinArenaBounds_UpdatesPlayerInfo )
+{
+   auto config = std::make_shared<GameConfig>();
+   config->ArenaWidth = 50;
+   config->ArenaHeight = 30;
+   config->PlayerStartDirection = Direction::Down;
+   config->PlayerStartX = 10;
+   config->PlayerStartY = 20;
+
+   auto game = std::shared_ptr<Game>( new Game( config,
+                                                std::make_shared<mock_GameEventAggregator>() ) );
+
+   game->ExecuteCommand( GameCommand::MovePlayerLeft );
+
+   EXPECT_EQ( game->GetPlayerDirection(), Direction::Left );
+   EXPECT_EQ( game->GetPlayerXPosition(), 9 );
+   EXPECT_EQ( game->GetPlayerYPosition(), 20 );
+}
+
+TEST( Game, ExecuteCommand_MovePlayerUpWithinArenaBounds_UpdatesPlayerInfo )
+{
+   auto config = std::make_shared<GameConfig>();
+   config->PlayerStartDirection = Direction::Down;
+   config->ArenaWidth = 50;
+   config->ArenaHeight = 30;
+   config->PlayerStartX = 10;
+   config->PlayerStartY = 20;
+
+   auto game = std::shared_ptr<Game>( new Game( config,
+                                                std::make_shared<mock_GameEventAggregator>() ) );
+
+   game->ExecuteCommand( GameCommand::MovePlayerUp );
+
+   EXPECT_EQ( game->GetPlayerDirection(), Direction::Up );
+   EXPECT_EQ( game->GetPlayerXPosition(), 10 );
+   EXPECT_EQ( game->GetPlayerYPosition(), 19 );
+}
+
+TEST( Game, ExecuteCommand_MovePlayerRightaWithinArenaBounds_UpdatesPlayerInfo )
+{
+   auto config = std::make_shared<GameConfig>();
+   config->ArenaWidth = 50;
+   config->ArenaHeight = 30;
+   config->PlayerStartDirection = Direction::Down;
+   config->PlayerStartX = 10;
+   config->PlayerStartY = 20;
+
+   auto game = std::shared_ptr<Game>( new Game( config,
+                                                std::make_shared<mock_GameEventAggregator>() ) );
+
+   game->ExecuteCommand( GameCommand::MovePlayerRight );
+
+   EXPECT_EQ( game->GetPlayerDirection(), Direction::Right );
+   EXPECT_EQ( game->GetPlayerXPosition(), 11 );
+   EXPECT_EQ( game->GetPlayerYPosition(), 20 );
+}
+
+TEST( Game, ExecuteCommand_MovePlayerDownWithinArenaBounds_UpdatesPlayerInfo )
+{
+   auto config = std::make_shared<GameConfig>();
+   config->ArenaWidth = 50;
+   config->ArenaHeight = 30;
+   config->PlayerStartDirection = Direction::Left;
+   config->PlayerStartX = 10;
+   config->PlayerStartY = 20;
+
+   auto game = std::shared_ptr<Game>( new Game( config,
+                                                std::make_shared<mock_GameEventAggregator>() ) );
+
+   game->ExecuteCommand( GameCommand::MovePlayerDown );
+
+   EXPECT_EQ( game->GetPlayerDirection(), Direction::Down );
+   EXPECT_EQ( game->GetPlayerXPosition(), 10 );
+   EXPECT_EQ( game->GetPlayerYPosition(), 21 );
+}
+
+TEST( Game, ExecuteCommand_MovePlayerLeftOutsideArenaBounds_DoesNotUpdatePlayerPosition )
+{
+   auto config = std::make_shared<GameConfig>();
+   config->ArenaWidth = 50;
+   config->ArenaHeight = 30;
+   config->PlayerStartDirection = Direction::Down;
+   config->PlayerStartX = 0;
+   config->PlayerStartY = 20;
+
+   auto game = std::shared_ptr<Game>( new Game( config,
+                                                std::make_shared<mock_GameEventAggregator>() ) );
+
+   game->ExecuteCommand( GameCommand::MovePlayerLeft );
+
+   EXPECT_EQ( game->GetPlayerDirection(), Direction::Left );
+   EXPECT_EQ( game->GetPlayerXPosition(), 0 );
+   EXPECT_EQ( game->GetPlayerYPosition(), 20 );
+}
+
+TEST( Game, ExecuteCommand_MovePlayerUpOutsideArenaBounds_DoesNotUpdatePlayerPosition )
+{
+   auto config = std::make_shared<GameConfig>();
+   config->ArenaWidth = 50;
+   config->ArenaHeight = 30;
+   config->PlayerStartDirection = Direction::Down;
+   config->PlayerStartX = 10;
+   config->PlayerStartY = 0;
+
+   auto game = std::shared_ptr<Game>( new Game( config,
+                                                std::make_shared<mock_GameEventAggregator>() ) );
+
+   game->ExecuteCommand( GameCommand::MovePlayerUp );
+
+   EXPECT_EQ( game->GetPlayerDirection(), Direction::Up );
+   EXPECT_EQ( game->GetPlayerXPosition(), 10 );
+   EXPECT_EQ( game->GetPlayerYPosition(), 0 );
+}
+
+TEST( Game, ExecuteCommand_MovePlayerRightOutsideArenaBounds_DoesNotUpdatePlayerPosition )
+{
+   auto config = std::make_shared<GameConfig>();
+   config->ArenaWidth = 50;
+   config->ArenaHeight = 30;
+   config->PlayerStartDirection = Direction::Down;
+   config->PlayerStartX = 49;
+   config->PlayerStartY = 20;
+
+   auto game = std::shared_ptr<Game>( new Game( config,
+                                                std::make_shared<mock_GameEventAggregator>() ) );
+
+   game->ExecuteCommand( GameCommand::MovePlayerRight );
+
+   EXPECT_EQ( game->GetPlayerDirection(), Direction::Right );
+   EXPECT_EQ( game->GetPlayerXPosition(), 49 );
+   EXPECT_EQ( game->GetPlayerYPosition(), 20 );
+}
+
+TEST( Game, ExecuteCommand_MovePlayerDownOutsideArenaBounds_DoesNotUpdatePlayerPosition )
+{
+   auto config = std::make_shared<GameConfig>();
+   config->ArenaWidth = 50;
+   config->ArenaHeight = 30;
+   config->PlayerStartDirection = Direction::Up;
+   config->PlayerStartX = 10;
+   config->PlayerStartY = 29;
+
+   auto game = std::shared_ptr<Game>( new Game( config,
+                                                std::make_shared<mock_GameEventAggregator>() ) );
+
+   game->ExecuteCommand( GameCommand::MovePlayerDown );
+
+   EXPECT_EQ( game->GetPlayerDirection(), Direction::Down );
+   EXPECT_EQ( game->GetPlayerXPosition(), 10 );
+   EXPECT_EQ( game->GetPlayerYPosition(), 29 );
 }

--- a/ConsoleGameTests/KeyboardInputReaderTests.cpp
+++ b/ConsoleGameTests/KeyboardInputReaderTests.cpp
@@ -1,0 +1,160 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <ConsoleGame/KeyboardInputReader.h>
+#include <ConsoleGame/GameInputConfig.h>
+#include <ConsoleGame/KeyCode.h>
+#include <ConsoleGame/GameButton.h>
+
+#include "mock_Keyboard.h"
+
+using namespace std;
+using namespace testing;
+using namespace ConsoleGame;
+
+class KeyboardInputReaderTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _inputConfig.reset( new GameInputConfig() );
+      _keyboardMock.reset( new mock_Keyboard() );
+   }
+
+   void AddKeyBinding( KeyCode keyCode, GameButton gameButton )
+   {
+      _inputConfig->KeyMap[keyCode] = gameButton;
+   }
+
+   void BuildInputReader()
+   {
+      _inputReader.reset( new KeyboardInputReader( _inputConfig,
+                                                   _keyboardMock ) );
+   }
+
+protected:
+   shared_ptr<GameInputConfig> _inputConfig;
+   shared_ptr<mock_Keyboard> _keyboardMock;
+
+   shared_ptr<KeyboardInputReader> _inputReader;
+};
+
+TEST_F( KeyboardInputReaderTests, ReadInput_ButtonWasPressed_MarksButtonAsDownAndPressed )
+{
+   AddKeyBinding( KeyCode::A, GameButton::A );
+   BuildInputReader();
+
+   EXPECT_CALL( *_keyboardMock, IsKeyDown( KeyCode::A ) ).WillRepeatedly( Return( true ) );
+
+   _inputReader->ReadInput();
+
+   EXPECT_TRUE( _inputReader->WasButtonPressed( GameButton::A ) );
+   EXPECT_TRUE( _inputReader->IsButtonDown( GameButton::A ) );
+}
+
+TEST_F( KeyboardInputReaderTests, ReadInput_ButtonIsDownAndWasAlreadyPressed_MarksButtonAsDownAndNotPressed )
+{
+   AddKeyBinding( KeyCode::A, GameButton::A );
+   BuildInputReader();
+
+   EXPECT_CALL( *_keyboardMock, IsKeyDown( KeyCode::A ) ).WillRepeatedly( Return( true ) );
+
+   _inputReader->ReadInput();
+   _inputReader->ReadInput();
+
+   EXPECT_FALSE( _inputReader->WasButtonPressed( GameButton::A ) );
+   EXPECT_TRUE( _inputReader->IsButtonDown( GameButton::A ) );
+}
+
+TEST_F( KeyboardInputReaderTests, ReadInput_ButtonWasReleased_MarksButtonAsUpAndNotPressed )
+{
+   AddKeyBinding( KeyCode::A, GameButton::A );
+   BuildInputReader();
+
+   EXPECT_CALL( *_keyboardMock, IsKeyDown( KeyCode::A ) )
+      .WillOnce( Return( true ) )
+      .WillOnce( Return( true ) )
+      .WillRepeatedly( Return( false ) );
+
+   _inputReader->ReadInput();
+   _inputReader->ReadInput();
+   _inputReader->ReadInput();
+
+   EXPECT_FALSE( _inputReader->WasButtonPressed( GameButton::A ) );
+   EXPECT_FALSE( _inputReader->IsButtonDown( GameButton::A ) );
+}
+
+TEST_F( KeyboardInputReaderTests, ReadInput_MultipleKeysBoundToButton_AllKeyBindingsWorkCorrectly )
+{
+   AddKeyBinding( KeyCode::A, GameButton::A );
+   AddKeyBinding( KeyCode::B, GameButton::A );
+   AddKeyBinding( KeyCode::C, GameButton::A );
+   BuildInputReader();
+
+   EXPECT_CALL( *_keyboardMock, IsKeyDown( KeyCode::A ) )
+      .WillOnce( Return( true ) )
+      .WillRepeatedly( Return( false ) );
+   EXPECT_CALL( *_keyboardMock, IsKeyDown( KeyCode::B ) )
+      .WillOnce( Return( true ) )
+      .WillRepeatedly( Return( false ) );
+   EXPECT_CALL( *_keyboardMock, IsKeyDown( KeyCode::C ) )
+      .WillOnce( Return( true ) )
+      .WillRepeatedly( Return( false ) );
+
+   _inputReader->ReadInput();
+
+   EXPECT_TRUE( _inputReader->WasButtonPressed( GameButton::A ) );
+   EXPECT_TRUE( _inputReader->IsButtonDown( GameButton::A ) );
+
+   _inputReader->ReadInput();
+
+   EXPECT_FALSE( _inputReader->WasButtonPressed( GameButton::A ) );
+   EXPECT_TRUE( _inputReader->IsButtonDown( GameButton::A ) );
+
+   _inputReader->ReadInput();
+
+   EXPECT_FALSE( _inputReader->WasButtonPressed( GameButton::A ) );
+   EXPECT_TRUE( _inputReader->IsButtonDown( GameButton::A ) );
+
+   _inputReader->ReadInput();
+
+   EXPECT_FALSE( _inputReader->WasButtonPressed( GameButton::A ) );
+   EXPECT_FALSE( _inputReader->IsButtonDown( GameButton::A ) );
+}
+
+TEST_F( KeyboardInputReaderTests, WasAnyButtonPressed_NoButtonWasPressed_ReturnsFalse )
+{
+   AddKeyBinding( KeyCode::A, GameButton::A );
+   BuildInputReader();
+
+   EXPECT_CALL( *_keyboardMock, IsKeyDown( _ ) ).WillRepeatedly( Return( false ) );
+
+   _inputReader->ReadInput();
+
+   EXPECT_FALSE( _inputReader->WasAnyButtonPressed() );
+}
+
+TEST_F( KeyboardInputReaderTests, WasAnyButtonPressed_DiagnosticsButtonWasPressed_ReturnsFalse )
+{
+   AddKeyBinding( KeyCode::F12, GameButton::Diagnostics );
+   BuildInputReader();
+
+   EXPECT_CALL( *_keyboardMock, IsKeyDown( KeyCode::F12 ) ).WillRepeatedly( Return( true ) );
+
+   _inputReader->ReadInput();
+
+   EXPECT_FALSE( _inputReader->WasAnyButtonPressed() );
+}
+
+TEST_F( KeyboardInputReaderTests, WasAnyButtonPressed_NonDiagnosticsButtonWasPressed_ReturnsTrue )
+{
+   AddKeyBinding( KeyCode::A, GameButton::A );
+   BuildInputReader();
+
+   EXPECT_CALL( *_keyboardMock, IsKeyDown( KeyCode::A ) ).WillRepeatedly( Return( true ) );
+
+   _inputReader->ReadInput();
+
+   EXPECT_TRUE( _inputReader->WasAnyButtonPressed() );
+}

--- a/ConsoleGameTests/PlayingStateInputHandlerTests.cpp
+++ b/ConsoleGameTests/PlayingStateInputHandlerTests.cpp
@@ -1,0 +1,101 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <ConsoleGame/PlayingStateInputHandler.h>
+#include <ConsoleGame/GameButton.h>
+#include <ConsoleGame/GameCommand.h>
+
+#include "mock_GameInputReader.h"
+#include "mock_GameCommandExecutor.h"
+
+using namespace std;
+using namespace testing;
+using namespace ConsoleGame;
+
+class PlayingStateInputHandlerTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _inputReader.reset( new mock_GameInputReader() );
+      _commandExecutor.reset( new mock_GameCommandExecutor() );
+
+      _inputHandler.reset( new PlayingStateInputHandler( _inputReader,
+                                                         _commandExecutor ) );
+   }
+
+protected:
+   shared_ptr<mock_GameInputReader> _inputReader;
+   shared_ptr<mock_GameCommandExecutor> _commandExecutor;
+
+   shared_ptr<PlayingStateInputHandler> _inputHandler;
+};
+
+TEST_F( PlayingStateInputHandlerTests, HandleInput_AButtonWasPressed_ExecutesQuitCommand )
+{
+   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( true ) );
+
+   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::Quit ) );
+
+   _inputHandler->HandleInput();
+}
+
+TEST_F( PlayingStateInputHandlerTests, HandleInput_LeftButtonIsDown_ExecutesMovePlayerLeftCommand )
+{
+   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Left ) ).WillOnce( Return( true ) );
+
+   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::MovePlayerLeft ) );
+
+   _inputHandler->HandleInput();
+}
+
+TEST_F( PlayingStateInputHandlerTests, HandleInput_UpButtonIsDown_ExecutesMovePlayerUpCommand )
+{
+   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Left ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Up ) ).WillOnce( Return( true ) );
+
+   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::MovePlayerUp ) );
+
+   _inputHandler->HandleInput();
+}
+
+TEST_F( PlayingStateInputHandlerTests, HandleInput_RightButtonIsDown_ExecutesMovePlayerRightCommand )
+{
+   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Left ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Up ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Right ) ).WillOnce( Return( true ) );
+
+   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::MovePlayerRight ) );
+
+   _inputHandler->HandleInput();
+}
+
+TEST_F( PlayingStateInputHandlerTests, HandleInput_DownButtonIsDown_ExecutesMovePlayerDownCommand )
+{
+   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Left ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Up ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Right ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Down ) ).WillOnce( Return( true ) );
+
+   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::MovePlayerDown ) );
+
+   _inputHandler->HandleInput();
+}
+
+TEST_F( PlayingStateInputHandlerTests, HandleInput_NoButtonsDown_DoesNotExecuteAnyCommand )
+{
+   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Left ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Up ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Right ) ).WillOnce( Return( false ) );
+   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Down ) ).WillOnce( Return( false ) );
+
+   EXPECT_CALL( *_commandExecutor, ExecuteCommand( _ ) ).Times( 0 );
+
+   _inputHandler->HandleInput();
+}

--- a/ConsoleGameTests/StartupStateInputHandlerTests.cpp
+++ b/ConsoleGameTests/StartupStateInputHandlerTests.cpp
@@ -1,0 +1,51 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+
+#include <ConsoleGame/StartupStateInputHandler.h>
+#include <ConsoleGame/GameButton.h>
+#include <ConsoleGame/GameCommand.h>
+
+#include "mock_GameInputReader.h"
+#include "mock_GameCommandExecutor.h"
+
+using namespace std;
+using namespace testing;
+using namespace ConsoleGame;
+
+class StartupStateInputHandlerTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _inputReader.reset( new mock_GameInputReader() );
+      _commandExecutor.reset( new mock_GameCommandExecutor() );
+
+      _inputHandler.reset( new StartupStateInputHandler( _inputReader,
+                                                         _commandExecutor ) );
+   }
+
+protected:
+   shared_ptr<mock_GameInputReader> _inputReader;
+   shared_ptr<mock_GameCommandExecutor> _commandExecutor;
+
+   shared_ptr<StartupStateInputHandler> _inputHandler;
+};
+
+TEST_F( StartupStateInputHandlerTests, HandleInput_NoButtonsWerePressed_DoesNotExecuteAnyCommand )
+{
+   EXPECT_CALL( *_inputReader, WasAnyButtonPressed() ).WillRepeatedly( Return( false ) );
+
+   EXPECT_CALL( *_commandExecutor, ExecuteCommand( _ ) ).Times( 0 );
+
+   _inputHandler->HandleInput();
+}
+
+TEST_F( StartupStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesStartCommand )
+{
+   EXPECT_CALL( *_inputReader, WasAnyButtonPressed() ).WillOnce( Return( true ) );
+
+   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::Start ) );
+
+   _inputHandler->HandleInput();
+}

--- a/ConsoleGameTests/mock_GameCommandExecutor.h
+++ b/ConsoleGameTests/mock_GameCommandExecutor.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <ConsoleGame/IGameCommandExecutor.h>
+
+class mock_GameCommandExecutor : public ConsoleGame::IGameCommandExecutor
+{
+public:
+   MOCK_METHOD( void, ExecuteCommand, ( ConsoleGame::GameCommand ), ( override ) );
+};

--- a/ConsoleGameTests/mock_GameEventAggregator.h
+++ b/ConsoleGameTests/mock_GameEventAggregator.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <ConsoleGame/IGameEventAggregator.h>
+
+class mock_GameEventAggregator : public ConsoleGame::IGameEventAggregator
+{
+public:
+   MOCK_METHOD( void, RegisterEventHandler, ( ConsoleGame::GameEvent, std::function<void()> ), ( override ) );
+   MOCK_METHOD( void, RaiseEvent, ( ConsoleGame::GameEvent ), ( const, override ) );
+};

--- a/ConsoleGameTests/mock_GameInputHandler.h
+++ b/ConsoleGameTests/mock_GameInputHandler.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <ConsoleGame/IGameInputHandler.h>
+
+class mock_GameInputHandler : public ConsoleGame::IGameInputHandler
+{
+public:
+   MOCK_METHOD( void, HandleInput, ( ), ( override ) );
+};

--- a/ConsoleGameTests/mock_GameInputReader.h
+++ b/ConsoleGameTests/mock_GameInputReader.h
@@ -4,8 +4,6 @@
 
 #include <ConsoleGame/IGameInputReader.h>
 
-enum class ConsoleGame::GameButton;
-
 class mock_GameInputReader : public ConsoleGame::IGameInputReader
 {
 public:

--- a/ConsoleGameTests/mock_GameInputReader.h
+++ b/ConsoleGameTests/mock_GameInputReader.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <ConsoleGame/IGameInputReader.h>
+
+enum class ConsoleGame::GameButton;
+
+class mock_GameInputReader : public ConsoleGame::IGameInputReader
+{
+public:
+   MOCK_METHOD( void, ReadInput, ( ), ( override ) );
+   MOCK_METHOD( bool, WasButtonPressed, ( ConsoleGame::GameButton ), ( const, override ) );
+   MOCK_METHOD( bool, IsButtonDown, ( ConsoleGame::GameButton ), ( const, override ) );
+   MOCK_METHOD( bool, WasAnyButtonPressed, ( ), ( const, override ) );
+};

--- a/ConsoleGameTests/mock_GameStateProvider.h
+++ b/ConsoleGameTests/mock_GameStateProvider.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <ConsoleGame/IGameStateProvider.h>
+
+class mock_GameStateProvider : public ConsoleGame::IGameStateProvider
+{
+public:
+   MOCK_METHOD( ConsoleGame::GameState, GetGameState, ( ), ( const, override ) );
+};

--- a/ConsoleGameTests/mock_HighResolutionClock.h
+++ b/ConsoleGameTests/mock_HighResolutionClock.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <ConsoleGame/IHighResolutionClock.h>
+
+class mock_HighResolutionClock : public ConsoleGame::IHighResolutionClock
+{
+public:
+   MOCK_METHOD( std::chrono::steady_clock::time_point, Now, ( ), ( override ) );
+};

--- a/ConsoleGameTests/mock_HighResolutionClock.h
+++ b/ConsoleGameTests/mock_HighResolutionClock.h
@@ -7,5 +7,5 @@
 class mock_HighResolutionClock : public ConsoleGame::IHighResolutionClock
 {
 public:
-   MOCK_METHOD( std::chrono::steady_clock::time_point, Now, ( ), ( override ) );
+   MOCK_METHOD( long long, Now, ( ), ( override ) );
 };

--- a/ConsoleGameTests/mock_Keyboard.h
+++ b/ConsoleGameTests/mock_Keyboard.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <ConsoleGame/IKeyboard.h>
+
+class mock_Keyboard : public ConsoleGame::IKeyboard
+{
+public:
+   MOCK_METHOD( bool, IsKeyDown, ( ConsoleGame::KeyCode ), ( const, override ) );
+};

--- a/ConsoleGameTests/mock_Sleeper.h
+++ b/ConsoleGameTests/mock_Sleeper.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <ConsoleGame/ISleeper.h>
+
+class mock_Sleeper : public ConsoleGame::ISleeper
+{
+public:
+   MOCK_METHOD( void, Sleep, ( unsigned long ), ( override ) );
+};

--- a/ConsoleGameTests/packages.config
+++ b/ConsoleGameTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
+</packages>

--- a/ConsoleGameTests/packages.config
+++ b/ConsoleGameTests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="gmock.v1.8" version="1.8.1" targetFramework="native" />
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
 </packages>

--- a/ConsoleGameTests/pch.cpp
+++ b/ConsoleGameTests/pch.cpp
@@ -1,0 +1,5 @@
+//
+// pch.cpp
+//
+
+#include "pch.h"

--- a/ConsoleGameTests/pch.cpp
+++ b/ConsoleGameTests/pch.cpp
@@ -1,5 +1,0 @@
-//
-// pch.cpp
-//
-
-#include "pch.h"

--- a/ConsoleGameTests/pch.h
+++ b/ConsoleGameTests/pch.h
@@ -1,7 +1,0 @@
-//
-// pch.h
-//
-
-#pragma once
-
-#include "gtest/gtest.h"

--- a/ConsoleGameTests/pch.h
+++ b/ConsoleGameTests/pch.h
@@ -1,0 +1,7 @@
+//
+// pch.h
+//
+
+#pragma once
+
+#include "gtest/gtest.h"

--- a/ConsoleGameTests/test.cpp
+++ b/ConsoleGameTests/test.cpp
@@ -1,0 +1,7 @@
+#include "pch.h"
+
+TEST( TestCaseName, TestName )
+{
+   EXPECT_EQ( 1, 1 );
+   EXPECT_TRUE( true );
+}

--- a/ConsoleGameTests/test.cpp
+++ b/ConsoleGameTests/test.cpp
@@ -1,7 +1,0 @@
-#include "pch.h"
-
-TEST( TestCaseName, TestName )
-{
-   EXPECT_EQ( 1, 1 );
-   EXPECT_TRUE( true );
-}


### PR DESCRIPTION
This sets up a second project in the solution for testing with the Google Test framework. I wasn't too familiar with the process, so I had to jump through a couple hoops to get it running. The goal is to leave the "ConsoleGame" project completely alone, and have the test project be a pure observer, so I had to do this:

- ConsoleGameTests is dependent on ConsoleGame
- In a pre-link build step, ConsoleGameTests compiles all of ConsoleGame's obj files into a .lib file in its own output folder
- ConsoleGameTests has an additional include folder of `$(solutionDir)`, so we can say `#include <ConsoleGame/Whatever.h>`, it looks nicer.

Despite all this, for some reason when a change is made in ConsoleWars, ConsoleWarsTests does not rebuild. I have no idea why, I figured if a dependency changes then it would do it automatically. There might be a setting somewhere for it, I'll open an issue.

Also, this PR doesn't include tests for everything. It avoids the following:

- `ConsoleDrawer`: This seemed large enough for its own PR. It would be nice to abstract all the Windows stuff into a wrapper, but I could see it being a little complicated. Should be fun to try though.
- Renderer classes (`GameConsoleRenderer` and each state renderer): It felt goofy to write tests for the state renderers, since we would mostly be checking the values of a bunch of strings being sent to the console drawer, and how frail the tests would be. `GameConsoleRenderer` should be tested, I just didn't get to it. :-)
- `GameEventAggregator`: I just didn't get to this either, but it should be tested. Integration tests would be good for this one.
- `GameRunner`: I don't really know quite how to test this one, since it halts execution until it receives a shutdown event. Maybe it can be done with threading? That's probably for another PR as well.