### PR TITLE
Use nice mocks in unit tests

### DIFF
--- a/ConsoleGameTests/GameClockTests.cpp
+++ b/ConsoleGameTests/GameClockTests.cpp
@@ -16,8 +16,8 @@ class GameClockTests : public Test
 public:
    void SetUp() override
    {
-      _highResolutionClockMock.reset( new mock_HighResolutionClock() );
-      _sleeperMock.reset( new mock_Sleeper() );
+      _highResolutionClockMock.reset( new NiceMock<mock_HighResolutionClock> );
+      _sleeperMock.reset( new NiceMock<mock_Sleeper> );
       _framesPerSecond = 100;
 
       _gameClock.reset( new GameClock( _highResolutionClockMock,
@@ -52,18 +52,12 @@ TEST_F( GameClockTests, Start_AlreadyRunning_DoesNotChangeValues )
 
 TEST_F( GameClockTests, Start_AfterPreviousRun_ResetsAllValues )
 {
-   EXPECT_CALL( *_highResolutionClockMock, Now() );
-
    _gameClock->Start();
 
-   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( 1'000'000ll ) );
-   EXPECT_CALL( *_sleeperMock, Sleep( _ ) );
+   ON_CALL( *_highResolutionClockMock, Now() ).WillByDefault( Return( 1'000'000ll ) );
 
    _gameClock->Tick();
    _gameClock->Stop();
-
-   EXPECT_CALL( *_highResolutionClockMock, Now() );
-
    _gameClock->Start();
 
    EXPECT_EQ( _gameClock->GetFramesPerSecond(), 100 );
@@ -80,12 +74,9 @@ TEST_F( GameClockTests, Tick_NotRunning_DoesNothing )
 
 TEST_F( GameClockTests, Tick_FrameIsCounted_IncrementsTotalFrames )
 {
-   EXPECT_CALL( *_highResolutionClockMock, Now() );
-
    _gameClock->Start();
 
-   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( 1ll ) );
-   EXPECT_CALL( *_sleeperMock, Sleep( _ ) );
+   ON_CALL( *_highResolutionClockMock, Now() ).WillByDefault( Return( 1ll ) );
 
    _gameClock->Tick();
 
@@ -94,11 +85,10 @@ TEST_F( GameClockTests, Tick_FrameIsCounted_IncrementsTotalFrames )
 
 TEST_F( GameClockTests, Tick_TimeIsLeftInFrame_SleepsForRemainingTime )
 {
-   EXPECT_CALL( *_highResolutionClockMock, Now() );
-
    _gameClock->Start();
 
-   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( 1'000'000ll ) );
+   ON_CALL( *_highResolutionClockMock, Now() ).WillByDefault( Return( 1'000'000ll ) );
+
    EXPECT_CALL( *_sleeperMock, Sleep( 9 ) );
 
    _gameClock->Tick();
@@ -106,13 +96,12 @@ TEST_F( GameClockTests, Tick_TimeIsLeftInFrame_SleepsForRemainingTime )
 
 TEST_F( GameClockTests, Tick_FrameIsOverTime_IncrementsLagFrames )
 {
-   EXPECT_CALL( *_highResolutionClockMock, Now() );
-
    _gameClock->Start();
 
    auto nanoSecondsPerFrame = 1'000'000'000ll / _framesPerSecond;
 
-   EXPECT_CALL( *_highResolutionClockMock, Now() ).WillOnce( Return( nanoSecondsPerFrame + 1ll ) );
+   ON_CALL( *_highResolutionClockMock, Now() ).WillByDefault( Return( nanoSecondsPerFrame + 1ll ) );
+
    EXPECT_CALL( *_sleeperMock, Sleep( _ ) ).Times( 0 );
 
    _gameClock->Tick();

--- a/ConsoleGameTests/GameInputHandlerTests.cpp
+++ b/ConsoleGameTests/GameInputHandlerTests.cpp
@@ -21,16 +21,16 @@ class GameInputHandlerTests : public Test
 public:
    void SetUp() override
    {
-      _inputReaderMock.reset( new mock_GameInputReader() );
-      _stateProviderMock.reset( new mock_GameStateProvider );
-      _eventAggregatorMock.reset( new mock_GameEventAggregator );
-      _startupInputHandler.reset( new mock_GameInputHandler );
+      _inputReaderMock.reset( new NiceMock<mock_GameInputReader> );
+      _stateProviderMock.reset( new NiceMock<mock_GameStateProvider> );
+      _eventAggregatorMock.reset( new NiceMock<mock_GameEventAggregator> );
+      _startupInputHandlerMock.reset( new NiceMock<mock_GameInputHandler> );
 
       _inputHandler.reset( new GameInputHandler( _inputReaderMock,
                                                  _stateProviderMock,
                                                  _eventAggregatorMock ) );
 
-      _inputHandler->AddInputHandlerForGameState( GameState::Startup, _startupInputHandler );
+      _inputHandler->AddInputHandlerForGameState( GameState::Startup, _startupInputHandlerMock );
 
       ON_CALL( *_stateProviderMock, GetGameState() ).WillByDefault( Return( GameState::Startup ) );
       ON_CALL( *_inputReaderMock, WasButtonPressed( _ ) ).WillByDefault( Return( false ) );
@@ -40,48 +40,43 @@ protected:
    shared_ptr<mock_GameInputReader> _inputReaderMock;
    shared_ptr<mock_GameStateProvider> _stateProviderMock;
    shared_ptr<mock_GameEventAggregator> _eventAggregatorMock;
-   shared_ptr<mock_GameInputHandler> _startupInputHandler;
+   shared_ptr<mock_GameInputHandler> _startupInputHandlerMock;
 
    shared_ptr<GameInputHandler> _inputHandler;
 };
 
-TEST_F( GameInputHandlerTests, HandleInput_Always_ReadsInputAndHandlesIt )
+TEST_F( GameInputHandlerTests, HandleInput_Always_ReadsInput )
 {
    EXPECT_CALL( *_inputReaderMock, ReadInput() );
-   EXPECT_CALL( *_inputReaderMock, WasButtonPressed( GameButton::Diagnostics ) );
-   EXPECT_CALL( *_stateProviderMock, GetGameState() );
-   EXPECT_CALL( *_startupInputHandler, HandleInput() );
 
    _inputHandler->HandleInput();
 }
 
 TEST_F( GameInputHandlerTests, HandleInput_DiagnosticsButtonWasNotPressed_DoesNotRaiseAnyEvents )
 {
-   EXPECT_CALL( *_inputReaderMock, ReadInput() );
-   EXPECT_CALL( *_inputReaderMock, WasButtonPressed( GameButton::Diagnostics ) );
    EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( _ ) ).Times( 0 );
-   EXPECT_CALL( *_stateProviderMock, GetGameState() );
-   EXPECT_CALL( *_startupInputHandler, HandleInput() );
 
    _inputHandler->HandleInput();
 }
 
 TEST_F( GameInputHandlerTests, HandleInput_DiagnosticsButtonWasPressed_RaisesToggleDiagnosticsEvent )
 {
-   EXPECT_CALL( *_inputReaderMock, ReadInput() );
-   EXPECT_CALL( *_inputReaderMock, WasButtonPressed( GameButton::Diagnostics ) ).WillRepeatedly ( Return( true ) );
-   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ToggleDiagnostics ) ).Times( 1 );
-   EXPECT_CALL( *_stateProviderMock, GetGameState() );
-   EXPECT_CALL( *_startupInputHandler, HandleInput() );
+   EXPECT_CALL( *_inputReaderMock, WasButtonPressed( GameButton::Diagnostics ) ).WillOnce( Return( true ) );
+   EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ToggleDiagnostics ) );
 
    _inputHandler->HandleInput();
 }
 
 TEST_F( GameInputHandlerTests, HandleInput_InputHandlerNotFoundForState_ThrowsException )
 {
-   EXPECT_CALL( *_inputReaderMock, ReadInput() );
-   EXPECT_CALL( *_inputReaderMock, WasButtonPressed( GameButton::Diagnostics ) );
    EXPECT_CALL( *_stateProviderMock, GetGameState() ).WillRepeatedly( Return( GameState::Playing ) );
 
    EXPECT_THROW( _inputHandler->HandleInput(), std::out_of_range );
+}
+
+TEST_F( GameInputHandlerTests, HandleInput_InputHandlerFoundForState_HandlesInputForState )
+{
+   EXPECT_CALL( *_startupInputHandlerMock, HandleInput() );
+
+   _inputHandler->HandleInput();
 }

--- a/ConsoleGameTests/GameInputHandlerTests.cpp
+++ b/ConsoleGameTests/GameInputHandlerTests.cpp
@@ -61,7 +61,7 @@ TEST_F( GameInputHandlerTests, HandleInput_DiagnosticsButtonWasNotPressed_DoesNo
 
 TEST_F( GameInputHandlerTests, HandleInput_DiagnosticsButtonWasPressed_RaisesToggleDiagnosticsEvent )
 {
-   EXPECT_CALL( *_inputReaderMock, WasButtonPressed( GameButton::Diagnostics ) ).WillOnce( Return( true ) );
+   ON_CALL( *_inputReaderMock, WasButtonPressed( GameButton::Diagnostics ) ).WillByDefault( Return( true ) );
    EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::ToggleDiagnostics ) );
 
    _inputHandler->HandleInput();
@@ -69,7 +69,7 @@ TEST_F( GameInputHandlerTests, HandleInput_DiagnosticsButtonWasPressed_RaisesTog
 
 TEST_F( GameInputHandlerTests, HandleInput_InputHandlerNotFoundForState_ThrowsException )
 {
-   EXPECT_CALL( *_stateProviderMock, GetGameState() ).WillRepeatedly( Return( GameState::Playing ) );
+   ON_CALL( *_stateProviderMock, GetGameState() ).WillByDefault( Return( GameState::Playing ) );
 
    EXPECT_THROW( _inputHandler->HandleInput(), std::out_of_range );
 }

--- a/ConsoleGameTests/GameTests.cpp
+++ b/ConsoleGameTests/GameTests.cpp
@@ -21,10 +21,12 @@ public:
    void SetUp() override
    {
       _config.reset( new GameConfig() );
-      _eventAggregatorMock.reset( new mock_GameEventAggregator() );
+      _eventAggregatorMock.reset( new NiceMock<mock_GameEventAggregator> );
+   }
 
-      _game.reset( new Game( _config,
-                             _eventAggregatorMock ) );
+   void BuildGame()
+   {
+      _game.reset( new Game( _config, _eventAggregatorMock ) );
    }
 
 protected:
@@ -36,26 +38,28 @@ protected:
 
 TEST_F( GameTests, Constructor_Always_SetsGameStateToStartup )
 {
+   BuildGame();
+
    EXPECT_EQ( _game->GetGameState(), GameState::Startup );
 }
 
 TEST_F( GameTests, Constructor_Always_SetsPlayerInfoBasedOnConfig )
 {
-   auto config = std::make_shared<GameConfig>();
-   config->PlayerStartDirection = Direction::Down;
-   config->PlayerStartX = 10;
-   config->PlayerStartY = 20;
+   _config->PlayerStartDirection = Direction::Down;
+   _config->PlayerStartX = 10;
+   _config->PlayerStartY = 20;
 
-   auto game = std::shared_ptr<Game>( new Game( config,
-                                                std::make_shared<mock_GameEventAggregator>() ) );
+   BuildGame();
 
-   EXPECT_EQ( game->GetPlayerDirection(), Direction::Down );
-   EXPECT_EQ( game->GetPlayerXPosition(), 10 );
-   EXPECT_EQ( game->GetPlayerYPosition(), 20 );
+   EXPECT_EQ( _game->GetPlayerDirection(), Direction::Down );
+   EXPECT_EQ( _game->GetPlayerXPosition(), 10 );
+   EXPECT_EQ( _game->GetPlayerYPosition(), 20 );
 }
 
 TEST_F( GameTests, ExecuteCommand_Start_SetsGameStateToPlaying )
 {
+   BuildGame();
+
    _game->ExecuteCommand( GameCommand::Start );
 
    EXPECT_EQ( _game->GetGameState(), GameState::Playing );
@@ -63,6 +67,8 @@ TEST_F( GameTests, ExecuteCommand_Start_SetsGameStateToPlaying )
 
 TEST_F( GameTests, ExecuteCommand_Quit_RaisesShutdownEvent )
 {
+   BuildGame();
+
    EXPECT_CALL( *_eventAggregatorMock, RaiseEvent( GameEvent::Shutdown ) ).Times( 1 );
 
    _game->ExecuteCommand( GameCommand::Quit );
@@ -70,152 +76,136 @@ TEST_F( GameTests, ExecuteCommand_Quit_RaisesShutdownEvent )
 
 TEST_F( GameTests, ExecuteCommand_MovePlayerLeftWithinArenaBounds_UpdatesPlayerInfo )
 {
-   auto config = std::make_shared<GameConfig>();
-   config->ArenaWidth = 50;
-   config->ArenaHeight = 30;
-   config->PlayerStartDirection = Direction::Down;
-   config->PlayerStartX = 10;
-   config->PlayerStartY = 20;
+   _config->ArenaWidth = 50;
+   _config->ArenaHeight = 30;
+   _config->PlayerStartDirection = Direction::Down;
+   _config->PlayerStartX = 10;
+   _config->PlayerStartY = 20;
 
-   auto game = std::shared_ptr<Game>( new Game( config,
-                                                std::make_shared<mock_GameEventAggregator>() ) );
+   BuildGame();
 
-   game->ExecuteCommand( GameCommand::MovePlayerLeft );
+   _game->ExecuteCommand( GameCommand::MovePlayerLeft );
 
-   EXPECT_EQ( game->GetPlayerDirection(), Direction::Left );
-   EXPECT_EQ( game->GetPlayerXPosition(), 9 );
-   EXPECT_EQ( game->GetPlayerYPosition(), 20 );
+   EXPECT_EQ( _game->GetPlayerDirection(), Direction::Left );
+   EXPECT_EQ( _game->GetPlayerXPosition(), 9 );
+   EXPECT_EQ( _game->GetPlayerYPosition(), 20 );
 }
 
 TEST_F( GameTests, ExecuteCommand_MovePlayerUpWithinArenaBounds_UpdatesPlayerInfo )
 {
-   auto config = std::make_shared<GameConfig>();
-   config->PlayerStartDirection = Direction::Down;
-   config->ArenaWidth = 50;
-   config->ArenaHeight = 30;
-   config->PlayerStartX = 10;
-   config->PlayerStartY = 20;
+   _config->PlayerStartDirection = Direction::Down;
+   _config->ArenaWidth = 50;
+   _config->ArenaHeight = 30;
+   _config->PlayerStartX = 10;
+   _config->PlayerStartY = 20;
 
-   auto game = std::shared_ptr<Game>( new Game( config,
-                                                std::make_shared<mock_GameEventAggregator>() ) );
+   BuildGame();
 
-   game->ExecuteCommand( GameCommand::MovePlayerUp );
+   _game->ExecuteCommand( GameCommand::MovePlayerUp );
 
-   EXPECT_EQ( game->GetPlayerDirection(), Direction::Up );
-   EXPECT_EQ( game->GetPlayerXPosition(), 10 );
-   EXPECT_EQ( game->GetPlayerYPosition(), 19 );
+   EXPECT_EQ( _game->GetPlayerDirection(), Direction::Up );
+   EXPECT_EQ( _game->GetPlayerXPosition(), 10 );
+   EXPECT_EQ( _game->GetPlayerYPosition(), 19 );
 }
 
 TEST_F( GameTests, ExecuteCommand_MovePlayerRightaWithinArenaBounds_UpdatesPlayerInfo )
 {
-   auto config = std::make_shared<GameConfig>();
-   config->ArenaWidth = 50;
-   config->ArenaHeight = 30;
-   config->PlayerStartDirection = Direction::Down;
-   config->PlayerStartX = 10;
-   config->PlayerStartY = 20;
+   _config->ArenaWidth = 50;
+   _config->ArenaHeight = 30;
+   _config->PlayerStartDirection = Direction::Down;
+   _config->PlayerStartX = 10;
+   _config->PlayerStartY = 20;
 
-   auto game = std::shared_ptr<Game>( new Game( config,
-                                                std::make_shared<mock_GameEventAggregator>() ) );
+   BuildGame();
 
-   game->ExecuteCommand( GameCommand::MovePlayerRight );
+   _game->ExecuteCommand( GameCommand::MovePlayerRight );
 
-   EXPECT_EQ( game->GetPlayerDirection(), Direction::Right );
-   EXPECT_EQ( game->GetPlayerXPosition(), 11 );
-   EXPECT_EQ( game->GetPlayerYPosition(), 20 );
+   EXPECT_EQ( _game->GetPlayerDirection(), Direction::Right );
+   EXPECT_EQ( _game->GetPlayerXPosition(), 11 );
+   EXPECT_EQ( _game->GetPlayerYPosition(), 20 );
 }
 
 TEST_F( GameTests, ExecuteCommand_MovePlayerDownWithinArenaBounds_UpdatesPlayerInfo )
 {
-   auto config = std::make_shared<GameConfig>();
-   config->ArenaWidth = 50;
-   config->ArenaHeight = 30;
-   config->PlayerStartDirection = Direction::Left;
-   config->PlayerStartX = 10;
-   config->PlayerStartY = 20;
+   _config->ArenaWidth = 50;
+   _config->ArenaHeight = 30;
+   _config->PlayerStartDirection = Direction::Left;
+   _config->PlayerStartX = 10;
+   _config->PlayerStartY = 20;
 
-   auto game = std::shared_ptr<Game>( new Game( config,
-                                                std::make_shared<mock_GameEventAggregator>() ) );
+   BuildGame();
 
-   game->ExecuteCommand( GameCommand::MovePlayerDown );
+   _game->ExecuteCommand( GameCommand::MovePlayerDown );
 
-   EXPECT_EQ( game->GetPlayerDirection(), Direction::Down );
-   EXPECT_EQ( game->GetPlayerXPosition(), 10 );
-   EXPECT_EQ( game->GetPlayerYPosition(), 21 );
+   EXPECT_EQ( _game->GetPlayerDirection(), Direction::Down );
+   EXPECT_EQ( _game->GetPlayerXPosition(), 10 );
+   EXPECT_EQ( _game->GetPlayerYPosition(), 21 );
 }
 
 TEST_F( GameTests, ExecuteCommand_MovePlayerLeftOutsideArenaBounds_DoesNotUpdatePlayerPosition )
 {
-   auto config = std::make_shared<GameConfig>();
-   config->ArenaWidth = 50;
-   config->ArenaHeight = 30;
-   config->PlayerStartDirection = Direction::Down;
-   config->PlayerStartX = 0;
-   config->PlayerStartY = 20;
+   _config->ArenaWidth = 50;
+   _config->ArenaHeight = 30;
+   _config->PlayerStartDirection = Direction::Down;
+   _config->PlayerStartX = 0;
+   _config->PlayerStartY = 20;
 
-   auto game = std::shared_ptr<Game>( new Game( config,
-                                                std::make_shared<mock_GameEventAggregator>() ) );
+   BuildGame();
 
-   game->ExecuteCommand( GameCommand::MovePlayerLeft );
+   _game->ExecuteCommand( GameCommand::MovePlayerLeft );
 
-   EXPECT_EQ( game->GetPlayerDirection(), Direction::Left );
-   EXPECT_EQ( game->GetPlayerXPosition(), 0 );
-   EXPECT_EQ( game->GetPlayerYPosition(), 20 );
+   EXPECT_EQ( _game->GetPlayerDirection(), Direction::Left );
+   EXPECT_EQ( _game->GetPlayerXPosition(), 0 );
+   EXPECT_EQ( _game->GetPlayerYPosition(), 20 );
 }
 
 TEST_F( GameTests, ExecuteCommand_MovePlayerUpOutsideArenaBounds_DoesNotUpdatePlayerPosition )
 {
-   auto config = std::make_shared<GameConfig>();
-   config->ArenaWidth = 50;
-   config->ArenaHeight = 30;
-   config->PlayerStartDirection = Direction::Down;
-   config->PlayerStartX = 10;
-   config->PlayerStartY = 0;
+   _config->ArenaWidth = 50;
+   _config->ArenaHeight = 30;
+   _config->PlayerStartDirection = Direction::Down;
+   _config->PlayerStartX = 10;
+   _config->PlayerStartY = 0;
 
-   auto game = std::shared_ptr<Game>( new Game( config,
-                                                std::make_shared<mock_GameEventAggregator>() ) );
+   BuildGame();
 
-   game->ExecuteCommand( GameCommand::MovePlayerUp );
+   _game->ExecuteCommand( GameCommand::MovePlayerUp );
 
-   EXPECT_EQ( game->GetPlayerDirection(), Direction::Up );
-   EXPECT_EQ( game->GetPlayerXPosition(), 10 );
-   EXPECT_EQ( game->GetPlayerYPosition(), 0 );
+   EXPECT_EQ( _game->GetPlayerDirection(), Direction::Up );
+   EXPECT_EQ( _game->GetPlayerXPosition(), 10 );
+   EXPECT_EQ( _game->GetPlayerYPosition(), 0 );
 }
 
 TEST_F( GameTests, ExecuteCommand_MovePlayerRightOutsideArenaBounds_DoesNotUpdatePlayerPosition )
 {
-   auto config = std::make_shared<GameConfig>();
-   config->ArenaWidth = 50;
-   config->ArenaHeight = 30;
-   config->PlayerStartDirection = Direction::Down;
-   config->PlayerStartX = 49;
-   config->PlayerStartY = 20;
+   _config->ArenaWidth = 50;
+   _config->ArenaHeight = 30;
+   _config->PlayerStartDirection = Direction::Down;
+   _config->PlayerStartX = 49;
+   _config->PlayerStartY = 20;
 
-   auto game = std::shared_ptr<Game>( new Game( config,
-                                                std::make_shared<mock_GameEventAggregator>() ) );
+   BuildGame();
 
-   game->ExecuteCommand( GameCommand::MovePlayerRight );
+   _game->ExecuteCommand( GameCommand::MovePlayerRight );
 
-   EXPECT_EQ( game->GetPlayerDirection(), Direction::Right );
-   EXPECT_EQ( game->GetPlayerXPosition(), 49 );
-   EXPECT_EQ( game->GetPlayerYPosition(), 20 );
+   EXPECT_EQ( _game->GetPlayerDirection(), Direction::Right );
+   EXPECT_EQ( _game->GetPlayerXPosition(), 49 );
+   EXPECT_EQ( _game->GetPlayerYPosition(), 20 );
 }
 
 TEST_F( GameTests, ExecuteCommand_MovePlayerDownOutsideArenaBounds_DoesNotUpdatePlayerPosition )
 {
-   auto config = std::make_shared<GameConfig>();
-   config->ArenaWidth = 50;
-   config->ArenaHeight = 30;
-   config->PlayerStartDirection = Direction::Up;
-   config->PlayerStartX = 10;
-   config->PlayerStartY = 29;
+   _config->ArenaWidth = 50;
+   _config->ArenaHeight = 30;
+   _config->PlayerStartDirection = Direction::Up;
+   _config->PlayerStartX = 10;
+   _config->PlayerStartY = 29;
 
-   auto game = std::shared_ptr<Game>( new Game( config,
-                                                std::make_shared<mock_GameEventAggregator>() ) );
+   BuildGame();
 
-   game->ExecuteCommand( GameCommand::MovePlayerDown );
+   _game->ExecuteCommand( GameCommand::MovePlayerDown );
 
-   EXPECT_EQ( game->GetPlayerDirection(), Direction::Down );
-   EXPECT_EQ( game->GetPlayerXPosition(), 10 );
-   EXPECT_EQ( game->GetPlayerYPosition(), 29 );
+   EXPECT_EQ( _game->GetPlayerDirection(), Direction::Down );
+   EXPECT_EQ( _game->GetPlayerXPosition(), 10 );
+   EXPECT_EQ( _game->GetPlayerYPosition(), 29 );
 }

--- a/ConsoleGameTests/KeyboardInputReaderTests.cpp
+++ b/ConsoleGameTests/KeyboardInputReaderTests.cpp
@@ -19,7 +19,7 @@ public:
    void SetUp() override
    {
       _inputConfig.reset( new GameInputConfig() );
-      _keyboardMock.reset( new mock_Keyboard() );
+      _keyboardMock.reset( new NiceMock<mock_Keyboard>() );
    }
 
    void AddKeyBinding( KeyCode keyCode, GameButton gameButton )

--- a/ConsoleGameTests/PlayingStateInputHandlerTests.cpp
+++ b/ConsoleGameTests/PlayingStateInputHandlerTests.cpp
@@ -18,84 +18,66 @@ class PlayingStateInputHandlerTests : public Test
 public:
    void SetUp() override
    {
-      _inputReader.reset( new mock_GameInputReader() );
-      _commandExecutor.reset( new mock_GameCommandExecutor() );
+      _inputReaderMock.reset( new NiceMock<mock_GameInputReader> );
+      _commandExecutorMock.reset( new NiceMock<mock_GameCommandExecutor> );
 
-      _inputHandler.reset( new PlayingStateInputHandler( _inputReader,
-                                                         _commandExecutor ) );
+      _inputHandler.reset( new PlayingStateInputHandler( _inputReaderMock,
+                                                         _commandExecutorMock ) );
+
+      ON_CALL( *_inputReaderMock, WasButtonPressed( _ ) ).WillByDefault( Return( false ) );
+      ON_CALL( *_inputReaderMock, IsButtonDown( _ ) ).WillByDefault( Return( false ) );
    }
 
 protected:
-   shared_ptr<mock_GameInputReader> _inputReader;
-   shared_ptr<mock_GameCommandExecutor> _commandExecutor;
+   shared_ptr<mock_GameInputReader> _inputReaderMock;
+   shared_ptr<mock_GameCommandExecutor> _commandExecutorMock;
 
    shared_ptr<PlayingStateInputHandler> _inputHandler;
 };
 
 TEST_F( PlayingStateInputHandlerTests, HandleInput_AButtonWasPressed_ExecutesQuitCommand )
 {
-   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( true ) );
-
-   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::Quit ) );
+   ON_CALL( *_inputReaderMock, WasButtonPressed( GameButton::A ) ).WillByDefault( Return( true ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::Quit ) );
 
    _inputHandler->HandleInput();
 }
 
 TEST_F( PlayingStateInputHandlerTests, HandleInput_LeftButtonIsDown_ExecutesMovePlayerLeftCommand )
 {
-   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Left ) ).WillOnce( Return( true ) );
-
-   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::MovePlayerLeft ) );
+   ON_CALL( *_inputReaderMock, IsButtonDown( GameButton::Left ) ).WillByDefault( Return( true ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayerLeft ) );
 
    _inputHandler->HandleInput();
 }
 
 TEST_F( PlayingStateInputHandlerTests, HandleInput_UpButtonIsDown_ExecutesMovePlayerUpCommand )
 {
-   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Left ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Up ) ).WillOnce( Return( true ) );
-
-   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::MovePlayerUp ) );
+   ON_CALL( *_inputReaderMock, IsButtonDown( GameButton::Up ) ).WillByDefault( Return( true ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayerUp ) );
 
    _inputHandler->HandleInput();
 }
 
 TEST_F( PlayingStateInputHandlerTests, HandleInput_RightButtonIsDown_ExecutesMovePlayerRightCommand )
 {
-   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Left ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Up ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Right ) ).WillOnce( Return( true ) );
-
-   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::MovePlayerRight ) );
+   ON_CALL( *_inputReaderMock, IsButtonDown( GameButton::Right ) ).WillByDefault( Return( true ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayerRight ) );
 
    _inputHandler->HandleInput();
 }
 
 TEST_F( PlayingStateInputHandlerTests, HandleInput_DownButtonIsDown_ExecutesMovePlayerDownCommand )
 {
-   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Left ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Up ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Right ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Down ) ).WillOnce( Return( true ) );
-
-   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::MovePlayerDown ) );
+   ON_CALL( *_inputReaderMock, IsButtonDown( GameButton::Down ) ).WillByDefault( Return( true ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayerDown ) );
 
    _inputHandler->HandleInput();
 }
 
 TEST_F( PlayingStateInputHandlerTests, HandleInput_NoButtonsDown_DoesNotExecuteAnyCommand )
 {
-   EXPECT_CALL( *_inputReader, WasButtonPressed( GameButton::A ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Left ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Up ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Right ) ).WillOnce( Return( false ) );
-   EXPECT_CALL( *_inputReader, IsButtonDown( GameButton::Down ) ).WillOnce( Return( false ) );
-
-   EXPECT_CALL( *_commandExecutor, ExecuteCommand( _ ) ).Times( 0 );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( _ ) ).Times( 0 );
 
    _inputHandler->HandleInput();
 }

--- a/ConsoleGameTests/StartupStateInputHandlerTests.cpp
+++ b/ConsoleGameTests/StartupStateInputHandlerTests.cpp
@@ -18,34 +18,34 @@ class StartupStateInputHandlerTests : public Test
 public:
    void SetUp() override
    {
-      _inputReader.reset( new mock_GameInputReader() );
-      _commandExecutor.reset( new mock_GameCommandExecutor() );
+      _inputReaderMock.reset( new NiceMock<mock_GameInputReader> );
+      _commandExecutorMock.reset( new NiceMock<mock_GameCommandExecutor> );
 
-      _inputHandler.reset( new StartupStateInputHandler( _inputReader,
-                                                         _commandExecutor ) );
+      _inputHandler.reset( new StartupStateInputHandler( _inputReaderMock,
+                                                         _commandExecutorMock ) );
    }
 
 protected:
-   shared_ptr<mock_GameInputReader> _inputReader;
-   shared_ptr<mock_GameCommandExecutor> _commandExecutor;
+   shared_ptr<mock_GameInputReader> _inputReaderMock;
+   shared_ptr<mock_GameCommandExecutor> _commandExecutorMock;
 
    shared_ptr<StartupStateInputHandler> _inputHandler;
 };
 
 TEST_F( StartupStateInputHandlerTests, HandleInput_NoButtonsWerePressed_DoesNotExecuteAnyCommand )
 {
-   EXPECT_CALL( *_inputReader, WasAnyButtonPressed() ).WillRepeatedly( Return( false ) );
+   ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( false ) );
 
-   EXPECT_CALL( *_commandExecutor, ExecuteCommand( _ ) ).Times( 0 );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( _ ) ).Times( 0 );
 
    _inputHandler->HandleInput();
 }
 
 TEST_F( StartupStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesStartCommand )
 {
-   EXPECT_CALL( *_inputReader, WasAnyButtonPressed() ).WillOnce( Return( true ) );
+   ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( true ) );
 
-   EXPECT_CALL( *_commandExecutor, ExecuteCommand( GameCommand::Start ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::Start ) );
 
    _inputHandler->HandleInput();
 }


### PR DESCRIPTION
I'm so happy this works, I was getting SICK of all the "uninteresting call on mock object" warnings. Turns out mock objects in the Google Test framework are automatically "naggy", meaning if a call is made on a mock object that you haven't put an `EXPECT_CALL` on, it'll output a warning message. Turns out if you wrap your mock object in a `NiceMock`, that warning message is suppressed. There's even a comment somewhere in the documentation that they're thinking of changing the default to be "nice", because it's pretty obnoxious.

Anyway, now we're using "nice" mocks everywhere, and it's a lot "nicer". 🥇 