### PR TITLE
Added unit tests for GameRunner

### DIFF
--- a/ConsoleGame/GameRunner.cpp
+++ b/ConsoleGame/GameRunner.cpp
@@ -16,7 +16,7 @@ GameRunner::GameRunner( const std::shared_ptr<IGameEventAggregator> eventAggrega
      _renderer( renderer ),
      _isRunning( false )
 {
-   eventAggregator->RegisterEventHandler( GameEvent::Shutdown, std::bind( &GameRunner::HandleQuitEvent, this ) );
+   eventAggregator->RegisterEventHandler( GameEvent::Shutdown, std::bind( &GameRunner::HandleShutdownEvent, this ) );
 }
 
 void GameRunner::Run()
@@ -35,7 +35,7 @@ void GameRunner::Run()
    _isRunning = false;
 }
 
-void GameRunner::HandleQuitEvent()
+void GameRunner::HandleShutdownEvent()
 {
    _isRunning = false;
 }

--- a/ConsoleGame/GameRunner.h
+++ b/ConsoleGame/GameRunner.h
@@ -22,7 +22,7 @@ namespace ConsoleGame
       void Run() override;
 
    private:
-      void HandleQuitEvent();
+      void HandleShutdownEvent();
 
    private:
       const std::shared_ptr<IGameClock> _clock;

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -53,6 +53,7 @@
     <ClCompile Include="GameConsoleRendererTests.cpp" />
     <ClCompile Include="GameEventAggregatorTests.cpp" />
     <ClCompile Include="GameInputHandlerTests.cpp" />
+    <ClCompile Include="GameRunnerTests.cpp" />
     <ClCompile Include="GameTests.cpp" />
     <ClCompile Include="KeyboardInputReaderTests.cpp" />
     <ClCompile Include="PlayingStateInputHandlerTests.cpp" />

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj
@@ -36,6 +36,7 @@
     <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
   </PropertyGroup>
   <ItemGroup>
+    <ClInclude Include="mock_GameClock.h" />
     <ClInclude Include="mock_ConsoleDrawer.h" />
     <ClInclude Include="mock_GameCommandExecutor.h" />
     <ClInclude Include="mock_GameEventAggregator.h" />

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -59,6 +59,9 @@
     <ClInclude Include="mock_GameRenderer.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="mock_GameClock.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
+++ b/ConsoleGameTests/ConsoleGameTests.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="GameConsoleRendererTests.cpp">
       <Filter>Tests\Render</Filter>
     </ClCompile>
+    <ClCompile Include="GameRunnerTests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mock_GameEventAggregator.h">

--- a/ConsoleGameTests/GameRunnerTests.cpp
+++ b/ConsoleGameTests/GameRunnerTests.cpp
@@ -1,0 +1,106 @@
+#include "gtest/gtest.h"
+
+#include <memory>
+#include <thread>
+
+#include <ConsoleGame/GameRunner.h>
+#include <ConsoleGame/GameEventAggregator.h>
+#include <ConsoleGame/GameEvent.h>
+
+#include "mock_GameClock.h"
+#include "mock_GameInputHandler.h"
+#include "mock_GameRenderer.h"
+
+using namespace std;
+using namespace testing;
+using namespace ConsoleGame;
+
+int TickCount = 0;
+int HandleInputCount = 0;
+int RenderCount = 0;
+
+void IncrementTickCount() { TickCount++; }
+void IncrementHandleInputCount () { HandleInputCount++; }
+void IncrementRenderCount () { RenderCount++; }
+
+void RunWorker( const shared_ptr<GameRunner> runner )
+{
+   runner->Run();
+}
+
+class GameRunnerTests : public Test
+{
+public:
+   void SetUp() override
+   {
+      _eventAggregator.reset( new GameEventAggregator );
+      _clockMock.reset( new NiceMock<mock_GameClock> );
+      _inputHandlerMock.reset( new NiceMock<mock_GameInputHandler> );
+      _rendererMock.reset( new NiceMock<mock_GameRenderer> );
+
+      _runner.reset( new GameRunner( _eventAggregator,
+                                     _clockMock,
+                                     _inputHandlerMock,
+                                     _rendererMock ) );
+
+      TickCount = 0;
+      HandleInputCount = 0;
+      RenderCount = 0;
+
+      ON_CALL( *_clockMock, Tick() ).WillByDefault( Invoke( IncrementTickCount ) );
+      ON_CALL( *_inputHandlerMock, HandleInput() ).WillByDefault( Invoke( IncrementHandleInputCount ) );
+      ON_CALL( *_rendererMock, Render() ).WillByDefault( Invoke( IncrementRenderCount ) );
+   }
+
+protected:
+   shared_ptr<GameEventAggregator> _eventAggregator;
+   shared_ptr<mock_GameClock> _clockMock;
+   shared_ptr<mock_GameInputHandler> _inputHandlerMock;
+   shared_ptr<mock_GameRenderer> _rendererMock;
+
+   shared_ptr<GameRunner> _runner;
+};
+
+TEST_F( GameRunnerTests, Run_Always_StartsClock )
+{
+   EXPECT_CALL( *_clockMock, Start() );
+
+   thread runWorker( RunWorker, _runner );
+   while( TickCount == 0 ) { }
+   _eventAggregator->RaiseEvent( GameEvent::Shutdown );
+
+   runWorker.join();
+}
+
+TEST_F( GameRunnerTests, Run_Always_StopsClock )
+{
+   thread runWorker( RunWorker, _runner );
+
+   while( TickCount == 0 ) { }
+   EXPECT_CALL( *_clockMock, Stop() );
+   _eventAggregator->RaiseEvent( GameEvent::Shutdown );
+
+   runWorker.join();
+}
+
+TEST_F( GameRunnerTests, Run_EveryLoop_RendersGame )
+{
+   thread runWorker( RunWorker, _runner );
+   while( TickCount < 10 ) { }
+   _eventAggregator->RaiseEvent( GameEvent::Shutdown );
+
+   runWorker.join();
+
+   EXPECT_EQ( RenderCount, TickCount );
+}
+
+TEST_F( GameRunnerTests, Run_EveryLoop_HandlesInput )
+{
+   thread runWorker( RunWorker, _runner );
+   while( TickCount < 10 ) { }
+   _eventAggregator->RaiseEvent( GameEvent::Shutdown );
+
+   runWorker.join();
+
+   EXPECT_EQ( HandleInputCount, TickCount );
+}

--- a/ConsoleGameTests/mock_GameClock.h
+++ b/ConsoleGameTests/mock_GameClock.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <gmock/gmock.h>
+#include <string>
+
+#include <ConsoleGame/IGameClock.h>
+
+class mock_GameClock : public ConsoleGame::IGameClock
+{
+public:
+   MOCK_METHOD( void, Start, ( ), ( override ) );
+   MOCK_METHOD( void, Tick, ( ), ( override ) );
+   MOCK_METHOD( void, Stop, ( ), ( override ) );
+
+   MOCK_METHOD( int, GetFramesPerSecond, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetTotalFrameCount, ( ), ( const, override ) );
+   MOCK_METHOD( long long, GetLagFrameCount, ( ), ( const, override ) );
+};


### PR DESCRIPTION
This wasn't so easy, because the game loop halts execution until a shutdown event is raised. I made it work by calling `Run()` in a `std::thread`, and keeping track of the number of ticks to decide when to raise a shutdown event.