### PR TITLE
Allow passing arguments along with game commands

### DIFF
--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -172,6 +172,7 @@
     <ClInclude Include="GameButton.h" />
     <ClInclude Include="GameClock.h" />
     <ClInclude Include="GameCommand.h" />
+    <ClInclude Include="GameCommandArgs.h" />
     <ClInclude Include="GameConfig.h" />
     <ClInclude Include="GameConsoleRenderer.h" />
     <ClInclude Include="GameEvent.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -199,6 +199,7 @@
     <ClInclude Include="ISleeper.h" />
     <ClInclude Include="KeyboardInputReader.h" />
     <ClInclude Include="KeyCode.h" />
+    <ClInclude Include="MovePlayerCommandArgs.h" />
     <ClInclude Include="PlayingStateConsoleRenderer.h" />
     <ClInclude Include="PlayingStateInputHandler.h" />
     <ClInclude Include="SleeperWrapper.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -212,5 +212,8 @@
     <ClInclude Include="KeyboardWrapper.h">
       <Filter>Header Files\Wrappers</Filter>
     </ClInclude>
+    <ClInclude Include="GameCommandArgs.h">
+      <Filter>Header Files\DataTypes</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -40,6 +40,9 @@
     <Filter Include="Source Files\Wrappers">
       <UniqueIdentifier>{60b226f4-2879-4bda-8b14-6cffa8d37e50}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\CommandArgs">
+      <UniqueIdentifier>{c79bef2d-4ae2-4f2d-979d-26aea4e9ea68}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ConsoleGame.cpp">
@@ -214,6 +217,9 @@
     </ClInclude>
     <ClInclude Include="GameCommandArgs.h">
       <Filter>Header Files\DataTypes</Filter>
+    </ClInclude>
+    <ClInclude Include="MovePlayerCommandArgs.h">
+      <Filter>Header Files\CommandArgs</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/ConsoleGame/Game.cpp
+++ b/ConsoleGame/Game.cpp
@@ -1,10 +1,11 @@
 #include "Game.h"
 #include "GameConfig.h"
+#include "IGameEventAggregator.h"
 #include "GameState.h"
 #include "GameCommand.h"
-#include "IGameEventAggregator.h"
 #include "GameEvent.h"
 #include "Direction.h"
+#include "MovePlayerCommandArgs.h"
 
 using namespace std;
 using namespace ConsoleGame;
@@ -22,6 +23,11 @@ Game::Game( const std::shared_ptr<GameConfig> config,
 
 void Game::ExecuteCommand( GameCommand command )
 {
+   ExecuteCommand( command, nullptr );
+}
+
+void Game::ExecuteCommand( GameCommand command, const shared_ptr<GameCommandArgs> args )
+{
    switch ( command )
    {
       case GameCommand::Start:
@@ -30,28 +36,39 @@ void Game::ExecuteCommand( GameCommand command )
       case GameCommand::Quit:
          _eventAggregator->RaiseEvent( GameEvent::Shutdown );
          break;
-      case GameCommand::MovePlayerLeft:
+      case GameCommand::MovePlayer:
+         auto direction = static_pointer_cast<MovePlayerCommandArgs>( args )->Direction;
+         MovePlayer( direction );
+         break;
+   }
+}
+
+void Game::MovePlayer( Direction direction )
+{
+   switch ( direction )
+   {
+      case Direction::Left:
          if ( _playerPositionX > 0 )
          {
             _playerPositionX--;
          }
          _playerDirection = Direction::Left;
          break;
-      case GameCommand::MovePlayerUp:
+      case Direction::Up:
          if ( _playerPositionY > 0 )
          {
             _playerPositionY--;
          }
          _playerDirection = Direction::Up;
          break;
-      case GameCommand::MovePlayerRight:
+      case Direction::Right:
          if ( _playerPositionX < _config->ArenaWidth - 1 )
          {
             _playerPositionX++;
          }
          _playerDirection = Direction::Right;
          break;
-      case GameCommand::MovePlayerDown:
+      case Direction::Down:
          if ( _playerPositionY < _config->ArenaHeight - 1 )
          {
             _playerPositionY++;

--- a/ConsoleGame/Game.h
+++ b/ConsoleGame/Game.h
@@ -9,8 +9,6 @@
 namespace ConsoleGame
 {
    class GameConfig;
-   enum class GameState;
-   enum class GameCommand;
    enum class Direction;
    class IGameEventAggregator;
 
@@ -24,11 +22,15 @@ namespace ConsoleGame
 
       GameState GetGameState() const override { return _state; }
 
-      void ExecuteCommand( GameCommand command );
+      void ExecuteCommand( GameCommand command ) override;
+      void ExecuteCommand( GameCommand command, const std::shared_ptr<GameCommandArgs> args ) override;
 
       Direction GetPlayerDirection() const override{ return _playerDirection; }
       int GetPlayerXPosition() const override { return _playerPositionX; }
       int GetPlayerYPosition() const override { return _playerPositionY; }
+
+   private:
+      void MovePlayer( Direction direction );
 
    private:
       const std::shared_ptr<GameConfig> _config;

--- a/ConsoleGame/GameCommand.h
+++ b/ConsoleGame/GameCommand.h
@@ -5,12 +5,7 @@ namespace ConsoleGame
    enum class GameCommand
    {
       Start = 0,
-
-      MovePlayerLeft,
-      MovePlayerUp,
-      MovePlayerRight,
-      MovePlayerDown,
-
+      MovePlayer,
       Quit
    };
 }

--- a/ConsoleGame/GameCommandArgs.h
+++ b/ConsoleGame/GameCommandArgs.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace ConsoleGame
+{
+   class GameCommandArgs { };
+}

--- a/ConsoleGame/IGameCommandExecutor.h
+++ b/ConsoleGame/IGameCommandExecutor.h
@@ -1,12 +1,16 @@
 #pragma once
 
+#include <memory>
+
 namespace ConsoleGame
 {
    enum class GameCommand;
+   class GameCommandArgs;
 
    class _declspec( novtable ) IGameCommandExecutor
    {
    public:
       virtual void ExecuteCommand( GameCommand command ) = 0;
+      virtual void ExecuteCommand( GameCommand command, const std::shared_ptr<GameCommandArgs> args ) = 0;
    };
 }

--- a/ConsoleGame/MovePlayerCommandArgs.h
+++ b/ConsoleGame/MovePlayerCommandArgs.h
@@ -9,6 +9,10 @@ namespace ConsoleGame
    class MovePlayerCommandArgs : public GameCommandArgs
    {
    public:
+      MovePlayerCommandArgs( Direction direction )
+         : Direction ( direction )
+      { }
+
       Direction Direction;
    };
 }

--- a/ConsoleGame/MovePlayerCommandArgs.h
+++ b/ConsoleGame/MovePlayerCommandArgs.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "GameCommandArgs.h"
+
+namespace ConsoleGame
+{
+   enum class Direction;
+
+   class MovePlayerCommandArgs : public GameCommandArgs
+   {
+   public:
+      Direction Direction;
+   };
+}

--- a/ConsoleGame/PlayingStateInputHandler.cpp
+++ b/ConsoleGame/PlayingStateInputHandler.cpp
@@ -3,6 +3,8 @@
 #include "IGameCommandExecutor.h"
 #include "GameButton.h"
 #include "GameCommand.h"
+#include "MovePlayerCommandArgs.h"
+#include "Direction.h"
 
 using namespace std;
 using namespace ConsoleGame;
@@ -22,18 +24,22 @@ void PlayingStateInputHandler::HandleInput()
    }
    else if ( _inputReader->IsButtonDown( GameButton::Left ) )
    {
-      _commandExecutor->ExecuteCommand( GameCommand::MovePlayerLeft );
+      _commandExecutor->ExecuteCommand( GameCommand::MovePlayer,
+                                        shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Left ) ) );
    }
    else if ( _inputReader->IsButtonDown( GameButton::Up ) )
    {
-      _commandExecutor->ExecuteCommand( GameCommand::MovePlayerUp );
+      _commandExecutor->ExecuteCommand( GameCommand::MovePlayer,
+                                        shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Up ) ) );
    }
    else if ( _inputReader->IsButtonDown( GameButton::Right ) )
    {
-      _commandExecutor->ExecuteCommand( GameCommand::MovePlayerRight );
+      _commandExecutor->ExecuteCommand( GameCommand::MovePlayer,
+                                        shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Right ) ) );
    }
    else if ( _inputReader->IsButtonDown( GameButton::Down ) )
    {
-      _commandExecutor->ExecuteCommand( GameCommand::MovePlayerDown );
+      _commandExecutor->ExecuteCommand( GameCommand::MovePlayer,
+                                        shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Down ) ) );
    }
 }

--- a/ConsoleGameTests/GameTests.cpp
+++ b/ConsoleGameTests/GameTests.cpp
@@ -8,6 +8,7 @@
 #include <ConsoleGame/Direction.h>
 #include <ConsoleGame/GameCommand.h>
 #include <ConsoleGame/GameEvent.h>
+#include <ConsoleGame/MovePlayerCommandArgs.h>
 
 #include "mock_GameEventAggregator.h"
 
@@ -84,7 +85,8 @@ TEST_F( GameTests, ExecuteCommand_MovePlayerLeftWithinArenaBounds_UpdatesPlayerI
 
    BuildGame();
 
-   _game->ExecuteCommand( GameCommand::MovePlayerLeft );
+   _game->ExecuteCommand( GameCommand::MovePlayer,
+                          shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Left ) ) );
 
    EXPECT_EQ( _game->GetPlayerDirection(), Direction::Left );
    EXPECT_EQ( _game->GetPlayerXPosition(), 9 );
@@ -101,7 +103,8 @@ TEST_F( GameTests, ExecuteCommand_MovePlayerUpWithinArenaBounds_UpdatesPlayerInf
 
    BuildGame();
 
-   _game->ExecuteCommand( GameCommand::MovePlayerUp );
+   _game->ExecuteCommand( GameCommand::MovePlayer,
+                          shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Up ) ) );
 
    EXPECT_EQ( _game->GetPlayerDirection(), Direction::Up );
    EXPECT_EQ( _game->GetPlayerXPosition(), 10 );
@@ -118,7 +121,8 @@ TEST_F( GameTests, ExecuteCommand_MovePlayerRightaWithinArenaBounds_UpdatesPlaye
 
    BuildGame();
 
-   _game->ExecuteCommand( GameCommand::MovePlayerRight );
+   _game->ExecuteCommand( GameCommand::MovePlayer,
+                          shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Right ) ) );
 
    EXPECT_EQ( _game->GetPlayerDirection(), Direction::Right );
    EXPECT_EQ( _game->GetPlayerXPosition(), 11 );
@@ -135,7 +139,8 @@ TEST_F( GameTests, ExecuteCommand_MovePlayerDownWithinArenaBounds_UpdatesPlayerI
 
    BuildGame();
 
-   _game->ExecuteCommand( GameCommand::MovePlayerDown );
+   _game->ExecuteCommand( GameCommand::MovePlayer,
+                          shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Down ) ) );
 
    EXPECT_EQ( _game->GetPlayerDirection(), Direction::Down );
    EXPECT_EQ( _game->GetPlayerXPosition(), 10 );
@@ -152,7 +157,8 @@ TEST_F( GameTests, ExecuteCommand_MovePlayerLeftOutsideArenaBounds_DoesNotUpdate
 
    BuildGame();
 
-   _game->ExecuteCommand( GameCommand::MovePlayerLeft );
+   _game->ExecuteCommand( GameCommand::MovePlayer,
+                          shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Left ) ) );
 
    EXPECT_EQ( _game->GetPlayerDirection(), Direction::Left );
    EXPECT_EQ( _game->GetPlayerXPosition(), 0 );
@@ -169,7 +175,8 @@ TEST_F( GameTests, ExecuteCommand_MovePlayerUpOutsideArenaBounds_DoesNotUpdatePl
 
    BuildGame();
 
-   _game->ExecuteCommand( GameCommand::MovePlayerUp );
+   _game->ExecuteCommand( GameCommand::MovePlayer,
+                          shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Up ) ) );
 
    EXPECT_EQ( _game->GetPlayerDirection(), Direction::Up );
    EXPECT_EQ( _game->GetPlayerXPosition(), 10 );
@@ -186,7 +193,8 @@ TEST_F( GameTests, ExecuteCommand_MovePlayerRightOutsideArenaBounds_DoesNotUpdat
 
    BuildGame();
 
-   _game->ExecuteCommand( GameCommand::MovePlayerRight );
+   _game->ExecuteCommand( GameCommand::MovePlayer,
+                          shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Right ) ) );
 
    EXPECT_EQ( _game->GetPlayerDirection(), Direction::Right );
    EXPECT_EQ( _game->GetPlayerXPosition(), 49 );
@@ -203,7 +211,8 @@ TEST_F( GameTests, ExecuteCommand_MovePlayerDownOutsideArenaBounds_DoesNotUpdate
 
    BuildGame();
 
-   _game->ExecuteCommand( GameCommand::MovePlayerDown );
+   _game->ExecuteCommand( GameCommand::MovePlayer,
+                          shared_ptr<MovePlayerCommandArgs>( new MovePlayerCommandArgs( Direction::Down ) ) );
 
    EXPECT_EQ( _game->GetPlayerDirection(), Direction::Down );
    EXPECT_EQ( _game->GetPlayerXPosition(), 10 );

--- a/ConsoleGameTests/PlayingStateInputHandlerTests.cpp
+++ b/ConsoleGameTests/PlayingStateInputHandlerTests.cpp
@@ -5,6 +5,8 @@
 #include <ConsoleGame/PlayingStateInputHandler.h>
 #include <ConsoleGame/GameButton.h>
 #include <ConsoleGame/GameCommand.h>
+#include <ConsoleGame/MovePlayerCommandArgs.h>
+#include <ConsoleGame/Direction.h>
 
 #include "mock_GameInputReader.h"
 #include "mock_GameCommandExecutor.h"
@@ -45,39 +47,51 @@ TEST_F( PlayingStateInputHandlerTests, HandleInput_AButtonWasPressed_ExecutesQui
 
 TEST_F( PlayingStateInputHandlerTests, HandleInput_LeftButtonIsDown_ExecutesMovePlayerLeftCommand )
 {
+   shared_ptr<GameCommandArgs> moveArgs;
    ON_CALL( *_inputReaderMock, IsButtonDown( GameButton::Left ) ).WillByDefault( Return( true ) );
-   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayerLeft ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayer, _ ) ).WillOnce( SaveArg<1>( &moveArgs ) );
 
    _inputHandler->HandleInput();
+
+   EXPECT_EQ( static_pointer_cast<MovePlayerCommandArgs>( moveArgs )->Direction, Direction::Left );
 }
 
 TEST_F( PlayingStateInputHandlerTests, HandleInput_UpButtonIsDown_ExecutesMovePlayerUpCommand )
 {
+   shared_ptr<GameCommandArgs> moveArgs;
    ON_CALL( *_inputReaderMock, IsButtonDown( GameButton::Up ) ).WillByDefault( Return( true ) );
-   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayerUp ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayer, _ ) ).WillOnce( SaveArg<1>( &moveArgs ) );
 
    _inputHandler->HandleInput();
+
+   EXPECT_EQ( static_pointer_cast<MovePlayerCommandArgs>( moveArgs )->Direction, Direction::Up );
 }
 
 TEST_F( PlayingStateInputHandlerTests, HandleInput_RightButtonIsDown_ExecutesMovePlayerRightCommand )
 {
+   shared_ptr<GameCommandArgs> moveArgs;
    ON_CALL( *_inputReaderMock, IsButtonDown( GameButton::Right ) ).WillByDefault( Return( true ) );
-   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayerRight ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayer, _ ) ).WillOnce( SaveArg<1>( &moveArgs ) );
 
    _inputHandler->HandleInput();
+
+   EXPECT_EQ( static_pointer_cast<MovePlayerCommandArgs>( moveArgs )->Direction, Direction::Right );
 }
 
 TEST_F( PlayingStateInputHandlerTests, HandleInput_DownButtonIsDown_ExecutesMovePlayerDownCommand )
 {
+   shared_ptr<GameCommandArgs> moveArgs;
    ON_CALL( *_inputReaderMock, IsButtonDown( GameButton::Down ) ).WillByDefault( Return( true ) );
-   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayerDown ) );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::MovePlayer, _ ) ).WillOnce( SaveArg<1>( &moveArgs ) );
 
    _inputHandler->HandleInput();
+
+   EXPECT_EQ( static_pointer_cast<MovePlayerCommandArgs>( moveArgs )->Direction, Direction::Down );
 }
 
 TEST_F( PlayingStateInputHandlerTests, HandleInput_NoButtonsDown_DoesNotExecuteAnyCommand )
 {
-   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( _ ) ).Times( 0 );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( _, _ ) ).Times( 0 );
 
    _inputHandler->HandleInput();
 }

--- a/ConsoleGameTests/StartupStateInputHandlerTests.cpp
+++ b/ConsoleGameTests/StartupStateInputHandlerTests.cpp
@@ -5,6 +5,7 @@
 #include <ConsoleGame/StartupStateInputHandler.h>
 #include <ConsoleGame/GameButton.h>
 #include <ConsoleGame/GameCommand.h>
+#include <ConsoleGame/GameCommandArgs.h>
 
 #include "mock_GameInputReader.h"
 #include "mock_GameCommandExecutor.h"
@@ -36,7 +37,7 @@ TEST_F( StartupStateInputHandlerTests, HandleInput_NoButtonsWerePressed_DoesNotE
 {
    ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( false ) );
 
-   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( _ ) ).Times( 0 );
+   EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( _, _ ) ).Times( 0 );
 
    _inputHandler->HandleInput();
 }
@@ -45,6 +46,7 @@ TEST_F( StartupStateInputHandlerTests, HandleInput_ButtonWasPressed_ExecutesStar
 {
    ON_CALL( *_inputReaderMock, WasAnyButtonPressed() ).WillByDefault( Return( true ) );
 
+   auto args = shared_ptr<GameCommandArgs>();
    EXPECT_CALL( *_commandExecutorMock, ExecuteCommand( GameCommand::Start ) );
 
    _inputHandler->HandleInput();

--- a/ConsoleGameTests/mock_GameCommandExecutor.h
+++ b/ConsoleGameTests/mock_GameCommandExecutor.h
@@ -8,4 +8,5 @@ class mock_GameCommandExecutor : public ConsoleGame::IGameCommandExecutor
 {
 public:
    MOCK_METHOD( void, ExecuteCommand, ( ConsoleGame::GameCommand ), ( override ) );
+   MOCK_METHOD( void, ExecuteCommand, ( ConsoleGame::GameCommand, const std::shared_ptr<ConsoleGame::GameCommandArgs> ), ( override ) );
 };


### PR DESCRIPTION
This will become necessary when commands eventually get more complicated. I added the base `GameCommandArgs` data class (which is empty for now), and the intention is make specific derivatives for each command that needs it. The example in here is `MovePlayerCommandArgs`, which has a `Direction` parameter. So when `Game` picks up a `MovePlayer` command, it will do a `static_pointer_cast<MovePlayerCommandArgs>` to get the direction.

I also left behind the old no-args version of `ExecuteCommand`, just as a shortcut if you don't want to pass any args.