### PR TITLE
Use "pixels" and "sprites" to draw the player

### DIFF
--- a/ConsoleGame/ConsoleDrawer.cpp
+++ b/ConsoleGame/ConsoleDrawer.cpp
@@ -6,6 +6,8 @@
 #include "ConsoleDrawer.h"
 #include "GameRenderConfig.h"
 #include "ConsoleColor.h"
+#include "ConsoleSprite.h"
+#include "ConsolePixel.h"
 
 namespace ConsoleGame
 {
@@ -134,6 +136,24 @@ void ConsoleDrawer::Draw( int left, int top, const string& buffer, ConsoleColor 
    for ( int i = 0; i < (int)buffer.length(); i++ )
    {
       Draw( left + i, top, buffer[i], foregroundColor, backgroundColor );
+   }
+}
+
+void ConsoleDrawer::Draw( int left, int top, const std::shared_ptr<ConsoleSprite> sprite )
+{
+   int i = 0, j = 0;
+
+   for ( auto pixel : sprite->Pixels )
+   {
+      Draw( left + i, top + j, pixel.Value, pixel.Color );
+
+      i++;
+
+      if ( i == sprite->Width )
+      {
+         i = 0;
+         j++;
+      }
    }
 }
 

--- a/ConsoleGame/ConsoleDrawer.cpp
+++ b/ConsoleGame/ConsoleDrawer.cpp
@@ -139,17 +139,17 @@ void ConsoleDrawer::Draw( int left, int top, const string& buffer, ConsoleColor 
    }
 }
 
-void ConsoleDrawer::Draw( int left, int top, const std::shared_ptr<ConsoleSprite> sprite )
+void ConsoleDrawer::Draw( int left, int top, const ConsoleSprite& sprite )
 {
    int i = 0, j = 0;
 
-   for ( auto pixel : sprite->Pixels )
+   for ( auto pixel : sprite.Pixels )
    {
       Draw( left + i, top + j, pixel.Value, pixel.Color );
 
       i++;
 
-      if ( i == sprite->Width )
+      if ( i == sprite.Width )
       {
          i = 0;
          j++;

--- a/ConsoleGame/ConsoleDrawer.h
+++ b/ConsoleGame/ConsoleDrawer.h
@@ -7,7 +7,6 @@
 namespace ConsoleGame
 {
    class GameRenderConfig;
-   enum class ConsoleColor;
    struct ConsoleBufferInfo;
 
    class ConsoleDrawer : public IConsoleDrawer
@@ -29,6 +28,7 @@ namespace ConsoleGame
       void Draw( int left, int top, const std::string& buffer ) override;
       void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor ) override;
       void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) override;
+      void Draw( int left, int top, const std::shared_ptr<ConsoleSprite> sprite ) override;
 
       void FlipDrawBuffer() override;
 

--- a/ConsoleGame/ConsoleDrawer.h
+++ b/ConsoleGame/ConsoleDrawer.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
 #include <memory>
 
 #include "IConsoleDrawer.h"
@@ -10,6 +8,7 @@ namespace ConsoleGame
 {
    class GameRenderConfig;
    enum class ConsoleColor;
+   struct ConsoleBufferInfo;
 
    class ConsoleDrawer : public IConsoleDrawer
    {
@@ -40,12 +39,7 @@ namespace ConsoleGame
    private:
       const std::shared_ptr<GameRenderConfig> _renderConfig;
 
-      HANDLE _outputHandle;
-      COORD _consoleSize;
-      int _drawBufferSize;
-      CHAR_INFO* _drawBuffer;
-      SMALL_RECT _outputRect;
-      COORD _zeroCoordinate = { 0, 0 };
+      std::shared_ptr<ConsoleBufferInfo> _bufferInfo;
 
       ConsoleColor _defaultForegroundColor;
       ConsoleColor _defaultBackgroundColor;

--- a/ConsoleGame/ConsoleDrawer.h
+++ b/ConsoleGame/ConsoleDrawer.h
@@ -28,7 +28,7 @@ namespace ConsoleGame
       void Draw( int left, int top, const std::string& buffer ) override;
       void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor ) override;
       void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) override;
-      void Draw( int left, int top, const std::shared_ptr<ConsoleSprite> sprite ) override;
+      void Draw( int left, int top, const ConsoleSprite& sprite ) override;
 
       void FlipDrawBuffer() override;
 

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -24,6 +24,7 @@
 #include "GameState.h"
 #include "ConsoleColor.h"
 #include "Direction.h"
+#include "ConsoleSprite.h"
 
 using namespace std;
 using namespace ConsoleGame;
@@ -94,6 +95,26 @@ shared_ptr<GameRenderConfig> BuildRenderConfig()
 
    renderConfig->DefaultForegroundColor = ConsoleColor::Grey;
    renderConfig->DefaultBackgroundColor = ConsoleColor::Black;
+
+   renderConfig->PlayerSpriteMap[Direction::Left].Width = 2;
+   renderConfig->PlayerSpriteMap[Direction::Left].Height = 1;
+   renderConfig->PlayerSpriteMap[Direction::Left].Pixels.push_back( { 'L', ConsoleColor::White } );
+   renderConfig->PlayerSpriteMap[Direction::Left].Pixels.push_back( { '-', ConsoleColor::White } );
+
+   renderConfig->PlayerSpriteMap[Direction::Right].Width = 2;
+   renderConfig->PlayerSpriteMap[Direction::Right].Height = 1;
+   renderConfig->PlayerSpriteMap[Direction::Right].Pixels.push_back( { '-', ConsoleColor::White } );
+   renderConfig->PlayerSpriteMap[Direction::Right].Pixels.push_back( { 'R', ConsoleColor::White } );
+
+   renderConfig->PlayerSpriteMap[Direction::Up].Width = 1;
+   renderConfig->PlayerSpriteMap[Direction::Up].Height = 2;
+   renderConfig->PlayerSpriteMap[Direction::Up].Pixels.push_back( { 'U', ConsoleColor::White } );
+   renderConfig->PlayerSpriteMap[Direction::Up].Pixels.push_back( { '|', ConsoleColor::White } );
+
+   renderConfig->PlayerSpriteMap[Direction::Down].Width = 1;
+   renderConfig->PlayerSpriteMap[Direction::Down].Height = 2;
+   renderConfig->PlayerSpriteMap[Direction::Down].Pixels.push_back( { '|', ConsoleColor::White } );
+   renderConfig->PlayerSpriteMap[Direction::Down].Pixels.push_back( { 'D', ConsoleColor::White } );
 
    return renderConfig;
 }

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -166,6 +166,7 @@
   <ItemGroup>
     <ClInclude Include="ConsoleColor.h" />
     <ClInclude Include="ConsoleDrawer.h" />
+    <ClInclude Include="ConsoleSprite.h" />
     <ClInclude Include="DiagnosticsConsoleRenderer.h" />
     <ClInclude Include="Direction.h" />
     <ClInclude Include="Game.h" />
@@ -200,6 +201,7 @@
     <ClInclude Include="KeyboardInputReader.h" />
     <ClInclude Include="KeyCode.h" />
     <ClInclude Include="MovePlayerCommandArgs.h" />
+    <ClInclude Include="ConsolePixel.h" />
     <ClInclude Include="PlayingStateConsoleRenderer.h" />
     <ClInclude Include="PlayingStateInputHandler.h" />
     <ClInclude Include="SleeperWrapper.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -221,5 +221,11 @@
     <ClInclude Include="MovePlayerCommandArgs.h">
       <Filter>Header Files\CommandArgs</Filter>
     </ClInclude>
+    <ClInclude Include="ConsolePixel.h">
+      <Filter>Header Files\DataTypes</Filter>
+    </ClInclude>
+    <ClInclude Include="ConsoleSprite.h">
+      <Filter>Header Files\DataTypes</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/ConsoleGame/ConsolePixel.h
+++ b/ConsoleGame/ConsolePixel.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace ConsoleGame
+{
+   enum class ConsoleColor;
+
+   struct ConsolePixel
+   {
+      char Value;
+      ConsoleColor Color;
+   };
+}

--- a/ConsoleGame/ConsoleSprite.h
+++ b/ConsoleGame/ConsoleSprite.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <vector>
+
+#include "ConsolePixel.h"
+
+namespace ConsoleGame
+{
+   struct ConsoleSprite
+   {
+      int Width;
+      int Height;
+
+      std::vector<ConsolePixel> Pixels;
+   };
+}

--- a/ConsoleGame/GameClock.cpp
+++ b/ConsoleGame/GameClock.cpp
@@ -54,7 +54,7 @@ void GameClock::Tick()
    }
 
    _totalFrameCount++;
-   _frameStartTimeNano = nowNano;
+   _frameStartTimeNano = _highResolutionClock->Now();
 }
 
 void GameClock::Stop()

--- a/ConsoleGame/GameRenderConfig.h
+++ b/ConsoleGame/GameRenderConfig.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <map>
+
 namespace ConsoleGame
 {
    enum class ConsoleColor;
+   enum class Direction;
+   struct ConsoleSprite;
 
    class GameRenderConfig
    {
@@ -15,5 +19,7 @@ namespace ConsoleGame
 
       ConsoleColor DefaultForegroundColor;
       ConsoleColor DefaultBackgroundColor;
+
+      std::map<Direction, ConsoleSprite> PlayerSpriteMap;
    };
 }

--- a/ConsoleGame/IConsoleDrawer.h
+++ b/ConsoleGame/IConsoleDrawer.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <string>
+#include <memory>
 
 namespace ConsoleGame
 {
    enum class ConsoleColor;
+   struct ConsoleSprite;
 
    class __declspec( novtable ) IConsoleDrawer
    {
@@ -22,6 +24,7 @@ namespace ConsoleGame
       virtual void Draw( int left, int top, const std::string& buffer ) = 0;
       virtual void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor ) = 0;
       virtual void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) = 0;
+      virtual void Draw( int left, int top, const std::shared_ptr<ConsoleSprite> sprite ) = 0;
 
       virtual void FlipDrawBuffer() = 0;
    };

--- a/ConsoleGame/IConsoleDrawer.h
+++ b/ConsoleGame/IConsoleDrawer.h
@@ -24,7 +24,7 @@ namespace ConsoleGame
       virtual void Draw( int left, int top, const std::string& buffer ) = 0;
       virtual void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor ) = 0;
       virtual void Draw( int left, int top, const std::string& buffer, ConsoleColor foregroundColor, ConsoleColor backgroundColor ) = 0;
-      virtual void Draw( int left, int top, const std::shared_ptr<ConsoleSprite> sprite ) = 0;
+      virtual void Draw( int left, int top, const ConsoleSprite& sprite ) = 0;
 
       virtual void FlipDrawBuffer() = 0;
    };

--- a/ConsoleGame/PlayingStateConsoleRenderer.cpp
+++ b/ConsoleGame/PlayingStateConsoleRenderer.cpp
@@ -20,34 +20,6 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<ICons
      _gameConfig( gameConfig ),
      _playerInfoProvider( playerInfoProvider )
 {
-   auto leftSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite );
-   leftSprite->Width = 2;
-   leftSprite->Height = 1;
-   leftSprite->Pixels.push_back( { 'L', ConsoleColor::White } );
-   leftSprite->Pixels.push_back( { '-', ConsoleColor::White } );
-
-   auto rightSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite );
-   rightSprite->Width = 2;
-   rightSprite->Height = 1;
-   rightSprite->Pixels.push_back( { '-', ConsoleColor::White } );
-   rightSprite->Pixels.push_back( { 'R', ConsoleColor::White } );
-
-   auto upSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite );
-   upSprite->Width = 1;
-   upSprite->Height = 2;
-   upSprite->Pixels.push_back( { 'U', ConsoleColor::White } );
-   upSprite->Pixels.push_back( { '|', ConsoleColor::White } );
-
-   auto downSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite );
-   downSprite->Width = 1;
-   downSprite->Height = 2;
-   downSprite->Pixels.push_back( { '|', ConsoleColor::White } );
-   downSprite->Pixels.push_back( { 'D', ConsoleColor::White } );
-
-   _playerSpriteMap[Direction::Left] = leftSprite;
-   _playerSpriteMap[Direction::Up] = upSprite;
-   _playerSpriteMap[Direction::Right] = rightSprite;
-   _playerSpriteMap[Direction::Down] = downSprite;
 }
 
 void PlayingStateConsoleRenderer::Render()
@@ -65,16 +37,16 @@ void PlayingStateConsoleRenderer::Render()
    switch ( _playerInfoProvider->GetPlayerDirection() )
    {
       case Direction::Left:
-         _consoleDrawer->Draw( playerX, playerY, _playerSpriteMap[Direction::Left] );
+         _consoleDrawer->Draw( playerX, playerY, _renderConfig->PlayerSpriteMap[Direction::Left] );
          break;
       case Direction::Up:
-         _consoleDrawer->Draw( playerX, playerY, _playerSpriteMap[Direction::Up] );
+         _consoleDrawer->Draw( playerX, playerY, _renderConfig->PlayerSpriteMap[Direction::Up] );
          break;
       case Direction::Right:
-         _consoleDrawer->Draw( playerX - 1, playerY, _playerSpriteMap[Direction::Right] );
+         _consoleDrawer->Draw( playerX - 1, playerY, _renderConfig->PlayerSpriteMap[Direction::Right] );
          break;
       case Direction::Down:
-         _consoleDrawer->Draw( playerX, playerY - 1, _playerSpriteMap[Direction::Down] );
+         _consoleDrawer->Draw( playerX, playerY - 1, _renderConfig->PlayerSpriteMap[Direction::Down] );
          break;
    }
 }

--- a/ConsoleGame/PlayingStateConsoleRenderer.cpp
+++ b/ConsoleGame/PlayingStateConsoleRenderer.cpp
@@ -5,6 +5,8 @@
 #include "IPlayerInfoProvider.h"
 #include "ConsoleColor.h"
 #include "Direction.h"
+#include "ConsoleSprite.h"
+#include "ConsolePixel.h"
 
 using namespace std;
 using namespace ConsoleGame;
@@ -18,6 +20,34 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<ICons
      _gameConfig( gameConfig ),
      _playerInfoProvider( playerInfoProvider )
 {
+   auto leftSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite );
+   leftSprite->Width = 2;
+   leftSprite->Height = 1;
+   leftSprite->Pixels.push_back( { 'L', ConsoleColor::White } );
+   leftSprite->Pixels.push_back( { '-', ConsoleColor::White } );
+
+   auto rightSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite );
+   rightSprite->Width = 2;
+   rightSprite->Height = 1;
+   rightSprite->Pixels.push_back( { '-', ConsoleColor::White } );
+   rightSprite->Pixels.push_back( { 'R', ConsoleColor::White } );
+
+   auto upSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite );
+   upSprite->Width = 1;
+   upSprite->Height = 2;
+   upSprite->Pixels.push_back( { 'U', ConsoleColor::White } );
+   upSprite->Pixels.push_back( { '|', ConsoleColor::White } );
+
+   auto downSprite = shared_ptr<ConsoleSprite>( new ConsoleSprite );
+   downSprite->Width = 1;
+   downSprite->Height = 2;
+   downSprite->Pixels.push_back( { '|', ConsoleColor::White } );
+   downSprite->Pixels.push_back( { 'D', ConsoleColor::White } );
+
+   _playerSpriteMap[Direction::Left] = leftSprite;
+   _playerSpriteMap[Direction::Up] = upSprite;
+   _playerSpriteMap[Direction::Right] = rightSprite;
+   _playerSpriteMap[Direction::Down] = downSprite;
 }
 
 void PlayingStateConsoleRenderer::Render()
@@ -29,11 +59,24 @@ void PlayingStateConsoleRenderer::Render()
 
    DrawArenaFence();
 
-   auto playerChar = GetPlayerCharFromDirection( _playerInfoProvider->GetPlayerDirection() );
    auto playerX = _playerInfoProvider->GetPlayerXPosition() + _renderConfig->ArenaFenceX + 1;
    auto playerY = _playerInfoProvider->GetPlayerYPosition() + _renderConfig->ArenaFenceY + 1;
 
-   _consoleDrawer->Draw( playerX, playerY, playerChar );
+   switch ( _playerInfoProvider->GetPlayerDirection() )
+   {
+      case Direction::Left:
+         _consoleDrawer->Draw( playerX, playerY, _playerSpriteMap[Direction::Left] );
+         break;
+      case Direction::Up:
+         _consoleDrawer->Draw( playerX, playerY, _playerSpriteMap[Direction::Up] );
+         break;
+      case Direction::Right:
+         _consoleDrawer->Draw( playerX - 1, playerY, _playerSpriteMap[Direction::Right] );
+         break;
+      case Direction::Down:
+         _consoleDrawer->Draw( playerX, playerY - 1, _playerSpriteMap[Direction::Down] );
+         break;
+   }
 }
 
 void PlayingStateConsoleRenderer::DrawArenaFence()
@@ -56,23 +99,5 @@ void PlayingStateConsoleRenderer::DrawArenaFence()
    {
       _consoleDrawer->Draw( _renderConfig->ArenaFenceX, top, '|' );
       _consoleDrawer->Draw( _renderConfig->ArenaFenceX + _gameConfig->ArenaWidth + 2, top, '|' );
-   }
-}
-
-char PlayingStateConsoleRenderer::GetPlayerCharFromDirection( Direction direction )
-{
-   switch ( direction )
-   {
-      case Direction::Left:
-         return '<';
-      case Direction::Up:
-         return '^';
-      case Direction::Right:
-         return '>';
-      case Direction::Down:
-         return 'V';
-
-      default:
-         return 'X';
    }
 }

--- a/ConsoleGame/PlayingStateConsoleRenderer.h
+++ b/ConsoleGame/PlayingStateConsoleRenderer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <map>
 
 #include "IGameRenderer.h"
 
@@ -10,6 +11,7 @@ namespace ConsoleGame
    class GameRenderConfig;
    class GameConfig;
    class IPlayerInfoProvider;
+   struct ConsoleSprite;
    enum class Direction;
 
    class PlayingStateConsoleRenderer : public IGameRenderer
@@ -24,12 +26,13 @@ namespace ConsoleGame
 
    private:
       void DrawArenaFence();
-      char GetPlayerCharFromDirection( Direction direction );
 
    private:
       const std::shared_ptr<IConsoleDrawer> _consoleDrawer;
       const std::shared_ptr<GameRenderConfig> _renderConfig;
       const std::shared_ptr<GameConfig> _gameConfig;
       const std::shared_ptr<IPlayerInfoProvider> _playerInfoProvider;
+
+      std::map<Direction, std::shared_ptr<ConsoleSprite>> _playerSpriteMap;
    };
 }

--- a/ConsoleGame/PlayingStateConsoleRenderer.h
+++ b/ConsoleGame/PlayingStateConsoleRenderer.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <map>
 
 #include "IGameRenderer.h"
 
@@ -11,8 +10,6 @@ namespace ConsoleGame
    class GameRenderConfig;
    class GameConfig;
    class IPlayerInfoProvider;
-   struct ConsoleSprite;
-   enum class Direction;
 
    class PlayingStateConsoleRenderer : public IGameRenderer
    {
@@ -32,7 +29,5 @@ namespace ConsoleGame
       const std::shared_ptr<GameRenderConfig> _renderConfig;
       const std::shared_ptr<GameConfig> _gameConfig;
       const std::shared_ptr<IPlayerInfoProvider> _playerInfoProvider;
-
-      std::map<Direction, std::shared_ptr<ConsoleSprite>> _playerSpriteMap;
    };
 }

--- a/ConsoleGameTests/GameConsoleRendererTests.cpp
+++ b/ConsoleGameTests/GameConsoleRendererTests.cpp
@@ -9,6 +9,7 @@
 #include <ConsoleGame/GameEventAggregator.h>
 #include <ConsoleGame/ConsoleColor.h>
 #include <ConsoleGame/GameState.h>
+#include <ConsoleGame/ConsoleSprite.h>
 
 #include "mock_ConsoleDrawer.h"
 #include "mock_GameStateProvider.h"

--- a/ConsoleGameTests/mock_ConsoleDrawer.h
+++ b/ConsoleGameTests/mock_ConsoleDrawer.h
@@ -20,7 +20,7 @@ public:
    MOCK_METHOD( void, Draw, ( int, int, const std::string& ), ( override ) );
    MOCK_METHOD( void, Draw, ( int, int, const std::string&, ConsoleGame::ConsoleColor ), ( override ) );
    MOCK_METHOD( void, Draw, ( int, int, const std::string&, ConsoleGame::ConsoleColor, ConsoleGame::ConsoleColor ), ( override ) );
-   MOCK_METHOD( void, Draw, ( int, int, const std::shared_ptr<ConsoleGame::ConsoleSprite> ), ( override ) );
+   MOCK_METHOD( void, Draw, ( int, int, const ConsoleGame::ConsoleSprite& ), ( override ) );
 
    MOCK_METHOD( void, FlipDrawBuffer, ( ), ( override ) );
 };

--- a/ConsoleGameTests/mock_ConsoleDrawer.h
+++ b/ConsoleGameTests/mock_ConsoleDrawer.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <gmock/gmock.h>
-#include <string>
 
 #include <ConsoleGame/IConsoleDrawer.h>
 
@@ -21,6 +20,7 @@ public:
    MOCK_METHOD( void, Draw, ( int, int, const std::string& ), ( override ) );
    MOCK_METHOD( void, Draw, ( int, int, const std::string&, ConsoleGame::ConsoleColor ), ( override ) );
    MOCK_METHOD( void, Draw, ( int, int, const std::string&, ConsoleGame::ConsoleColor, ConsoleGame::ConsoleColor ), ( override ) );
+   MOCK_METHOD( void, Draw, ( int, int, const std::shared_ptr<ConsoleGame::ConsoleSprite> ), ( override ) );
 
    MOCK_METHOD( void, FlipDrawBuffer, ( ), ( override ) );
 };


### PR DESCRIPTION
I thought this would probably be a commonly-used thing in any game written with this codebase, so it should be available from the start. I added `ConsolePixel` and `ConsoleSprite` structs, so the player can have individual sprites for each direction they're facing.

BONUS: I moved the Windows-specific objects and includes out of ConsoleDrawer.h and into ConsoleDrawer.cpp, it was bugging me.