### PR TITLE
Make Render and Input configs more generic

### DIFF
--- a/ConsoleGame/ConsoleDrawer.cpp
+++ b/ConsoleGame/ConsoleDrawer.cpp
@@ -4,7 +4,7 @@
 #include <format>
 
 #include "ConsoleDrawer.h"
-#include "GameRenderConfig.h"
+#include "ConsoleRenderConfig.h"
 #include "ConsoleColor.h"
 #include "ConsoleSprite.h"
 #include "ConsolePixel.h"
@@ -25,7 +25,7 @@ namespace ConsoleGame
 using namespace std;
 using namespace ConsoleGame;
 
-ConsoleDrawer::ConsoleDrawer( const shared_ptr<GameRenderConfig> renderConfig )
+ConsoleDrawer::ConsoleDrawer( const shared_ptr<ConsoleRenderConfig> renderConfig )
    : _renderConfig( renderConfig ),
      _defaultForegroundColor( ConsoleColor::Grey ),
      _defaultBackgroundColor( ConsoleColor::Black )

--- a/ConsoleGame/ConsoleDrawer.h
+++ b/ConsoleGame/ConsoleDrawer.h
@@ -6,13 +6,13 @@
 
 namespace ConsoleGame
 {
-   class GameRenderConfig;
+   class ConsoleRenderConfig;
    struct ConsoleBufferInfo;
 
    class ConsoleDrawer : public IConsoleDrawer
    {
    public:
-      ConsoleDrawer( const std::shared_ptr<GameRenderConfig> renderConfig );
+      ConsoleDrawer( const std::shared_ptr<ConsoleRenderConfig> renderConfig );
       ~ConsoleDrawer();
 
       void Initialize() override;
@@ -37,7 +37,7 @@ namespace ConsoleGame
       unsigned short ConsoleColorsToAttribute( ConsoleColor foregroundColor, ConsoleColor backgroundColor );
 
    private:
-      const std::shared_ptr<GameRenderConfig> _renderConfig;
+      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
 
       std::shared_ptr<ConsoleBufferInfo> _bufferInfo;
 

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -178,7 +178,7 @@
     <ClInclude Include="GameConsoleRenderer.h" />
     <ClInclude Include="GameEvent.h" />
     <ClInclude Include="GameEventAggregator.h" />
-    <ClInclude Include="GameRenderConfig.h" />
+    <ClInclude Include="ConsoleRenderConfig.h" />
     <ClInclude Include="GameRunner.h" />
     <ClInclude Include="GameState.h" />
     <ClInclude Include="IGameRenderConfig.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -181,6 +181,7 @@
     <ClInclude Include="ConsoleRenderConfig.h" />
     <ClInclude Include="GameRunner.h" />
     <ClInclude Include="GameState.h" />
+    <ClInclude Include="IGameInputConfig.h" />
     <ClInclude Include="IGameRenderConfig.h" />
     <ClInclude Include="KeyboardWrapper.h" />
     <ClInclude Include="HighResolutionClockWrapper.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -194,7 +194,7 @@
     <ClInclude Include="IGameRenderer.h" />
     <ClInclude Include="IGameRunner.h" />
     <ClInclude Include="GameInputHandler.h" />
-    <ClInclude Include="GameInputConfig.h" />
+    <ClInclude Include="KeyboardInputConfig.h" />
     <ClInclude Include="IGameStateProvider.h" />
     <ClInclude Include="IHighResolutionClock.h" />
     <ClInclude Include="IKeyboard.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -181,6 +181,7 @@
     <ClInclude Include="GameRenderConfig.h" />
     <ClInclude Include="GameRunner.h" />
     <ClInclude Include="GameState.h" />
+    <ClInclude Include="IGameRenderConfig.h" />
     <ClInclude Include="KeyboardWrapper.h" />
     <ClInclude Include="HighResolutionClockWrapper.h" />
     <ClInclude Include="IGameCommandExecutor.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -173,7 +173,7 @@
     <ClInclude Include="ConsoleRenderConfig.h">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
-    <ClInclude Include="GameInputConfig.h">
+    <ClInclude Include="KeyboardInputConfig.h">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
     <ClInclude Include="DiagnosticsConsoleRenderer.h">

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -230,5 +230,8 @@
     <ClInclude Include="IGameRenderConfig.h">
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
+    <ClInclude Include="IGameInputConfig.h">
+      <Filter>Header Files\Interfaces</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -170,7 +170,7 @@
     <ClInclude Include="GameConfig.h">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
-    <ClInclude Include="GameRenderConfig.h">
+    <ClInclude Include="ConsoleRenderConfig.h">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
     <ClInclude Include="GameInputConfig.h">

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -227,5 +227,8 @@
     <ClInclude Include="ConsoleSprite.h">
       <Filter>Header Files\DataTypes</Filter>
     </ClInclude>
+    <ClInclude Include="IGameRenderConfig.h">
+      <Filter>Header Files\Interfaces</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/ConsoleGame/ConsoleRenderConfig.h
+++ b/ConsoleGame/ConsoleRenderConfig.h
@@ -2,13 +2,15 @@
 
 #include <map>
 
+#include "IGameRenderConfig.h"
+
 namespace ConsoleGame
 {
    enum class ConsoleColor;
    enum class Direction;
    struct ConsoleSprite;
 
-   class GameRenderConfig
+   class ConsoleRenderConfig : public IGameRenderConfig
    {
    public:
       short ConsoleWidth;

--- a/ConsoleGame/DiagnosticsConsoleRenderer.cpp
+++ b/ConsoleGame/DiagnosticsConsoleRenderer.cpp
@@ -3,7 +3,7 @@
 #include "DiagnosticsConsoleRenderer.h"
 #include "IConsoleDrawer.h"
 #include "IGameClock.h"
-#include "GameRenderConfig.h"
+#include "ConsoleRenderConfig.h"
 #include "ConsoleColor.h"
 
 #define DIAGNOSTICS_WIDTH 30
@@ -13,7 +13,7 @@ using namespace ConsoleGame;
 
 DiagnosticsConsoleRenderer::DiagnosticsConsoleRenderer( const shared_ptr<IConsoleDrawer> consoleDrawer,
                                                         const shared_ptr<IGameClock> clock,
-                                                        const shared_ptr<GameRenderConfig> renderConfig )
+                                                        const shared_ptr<ConsoleRenderConfig> renderConfig )
    : _consoleDrawer( consoleDrawer ),
      _clock( clock ),
      _renderConfig( renderConfig )

--- a/ConsoleGame/DiagnosticsConsoleRenderer.h
+++ b/ConsoleGame/DiagnosticsConsoleRenderer.h
@@ -8,20 +8,20 @@ namespace ConsoleGame
 {
    class IConsoleDrawer;
    class IGameClock;
-   class GameRenderConfig;
+   class ConsoleRenderConfig;
 
    class DiagnosticsConsoleRenderer : public IGameRenderer
    {
    public:
       DiagnosticsConsoleRenderer( const std::shared_ptr<IConsoleDrawer> consoleDrawer,
                                   const std::shared_ptr<IGameClock> clock,
-                                  const std::shared_ptr<GameRenderConfig> renderConfig );
+                                  const std::shared_ptr<ConsoleRenderConfig> renderConfig );
 
       void Render() override;
 
    private:
       const std::shared_ptr<IConsoleDrawer> _consoleDrawer;
       const std::shared_ptr<IGameClock> _clock;
-      const std::shared_ptr<GameRenderConfig> _renderConfig;
+      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
    };
 }

--- a/ConsoleGame/GameConfig.h
+++ b/ConsoleGame/GameConfig.h
@@ -4,7 +4,7 @@
 
 namespace ConsoleGame
 {
-   class GameRenderConfig;
+   class IGameRenderConfig;
    class GameInputConfig;
    enum class Direction;
 
@@ -20,7 +20,7 @@ namespace ConsoleGame
       short PlayerStartX;
       short PlayerStartY;
 
-      std::shared_ptr<GameRenderConfig> RenderConfig;
+      std::shared_ptr<IGameRenderConfig> RenderConfig;
       std::shared_ptr<GameInputConfig> InputConfig;
    };
 }

--- a/ConsoleGame/GameConfig.h
+++ b/ConsoleGame/GameConfig.h
@@ -5,7 +5,7 @@
 namespace ConsoleGame
 {
    class IGameRenderConfig;
-   class GameInputConfig;
+   class IGameInputConfig;
    enum class Direction;
 
    class GameConfig
@@ -21,6 +21,6 @@ namespace ConsoleGame
       short PlayerStartY;
 
       std::shared_ptr<IGameRenderConfig> RenderConfig;
-      std::shared_ptr<GameInputConfig> InputConfig;
+      std::shared_ptr<IGameInputConfig> InputConfig;
    };
 }

--- a/ConsoleGame/GameConsoleRenderer.cpp
+++ b/ConsoleGame/GameConsoleRenderer.cpp
@@ -1,7 +1,7 @@
 #include <format>
 
 #include "GameConsoleRenderer.h"
-#include "GameRenderConfig.h"
+#include "ConsoleRenderConfig.h"
 #include "IConsoleDrawer.h"
 #include "IGameStateProvider.h"
 #include "IGameEventAggregator.h"
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace ConsoleGame;
 
-GameConsoleRenderer::GameConsoleRenderer( const shared_ptr<GameRenderConfig> renderConfig,
+GameConsoleRenderer::GameConsoleRenderer( const shared_ptr<ConsoleRenderConfig> renderConfig,
                                           const shared_ptr<IConsoleDrawer> consoleDrawer,
                                           const shared_ptr<IGameStateProvider> stateProvider,
                                           const shared_ptr<IGameRenderer> diagnosticsRenderer,

--- a/ConsoleGame/GameConsoleRenderer.h
+++ b/ConsoleGame/GameConsoleRenderer.h
@@ -8,7 +8,7 @@
 
 namespace ConsoleGame
 {
-   class GameRenderConfig;
+   class ConsoleRenderConfig;
    class IConsoleDrawer;
    class IGameStateProvider;
    class IGameEventAggregator;
@@ -18,7 +18,7 @@ namespace ConsoleGame
    class GameConsoleRenderer : public IGameRenderer
    {
    public:
-      GameConsoleRenderer( const std::shared_ptr<GameRenderConfig> renderConfig,
+      GameConsoleRenderer( const std::shared_ptr<ConsoleRenderConfig> renderConfig,
                            const std::shared_ptr<IConsoleDrawer> consoleDrawer,
                            const std::shared_ptr<IGameStateProvider> stateProvider,
                            const std::shared_ptr<IGameRenderer> diagnosticsRenderer,

--- a/ConsoleGame/IGameInputConfig.h
+++ b/ConsoleGame/IGameInputConfig.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace ConsoleGame
+{
+   class __declspec( novtable ) IGameInputConfig { };
+}

--- a/ConsoleGame/IGameRenderConfig.h
+++ b/ConsoleGame/IGameRenderConfig.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace ConsoleGame
+{
+   class _declspec(novtable) IGameRenderConfig { };
+}

--- a/ConsoleGame/KeyboardInputConfig.h
+++ b/ConsoleGame/KeyboardInputConfig.h
@@ -3,12 +3,14 @@
 #include <map>
 #include <string>
 
+#include "IGameInputConfig.h"
+
 namespace ConsoleGame
 {
    enum class KeyCode;
    enum class GameButton;
 
-   class GameInputConfig
+   class KeyboardInputConfig : public IGameInputConfig
    {
    public:
       std::map<KeyCode, GameButton> KeyMap;

--- a/ConsoleGame/KeyboardInputReader.cpp
+++ b/ConsoleGame/KeyboardInputReader.cpp
@@ -1,5 +1,5 @@
 #include "KeyboardInputReader.h"
-#include "GameInputConfig.h"
+#include "KeyboardInputConfig.h"
 #include "IKeyboard.h"
 #include "KeyCode.h"
 #include "GameButton.h"
@@ -7,7 +7,7 @@
 using namespace std;
 using namespace ConsoleGame;
 
-KeyboardInputReader::KeyboardInputReader( const shared_ptr<GameInputConfig> inputConfig,
+KeyboardInputReader::KeyboardInputReader( const shared_ptr<KeyboardInputConfig> inputConfig,
                                           const shared_ptr<IKeyboard> keyboard )
    : _keyboard( keyboard )
 {

--- a/ConsoleGame/KeyboardInputReader.h
+++ b/ConsoleGame/KeyboardInputReader.h
@@ -14,7 +14,7 @@ namespace ConsoleGame
       bool ButtonIsDown;
    };
 
-   class GameInputConfig;
+   class KeyboardInputConfig;
    class IKeyboard;
    enum class KeyCode;
    enum class GameButton;
@@ -22,7 +22,7 @@ namespace ConsoleGame
    class KeyboardInputReader : public IGameInputReader
    {
    public:
-      KeyboardInputReader( const std::shared_ptr<GameInputConfig> inputConfig,
+      KeyboardInputReader( const std::shared_ptr<KeyboardInputConfig> inputConfig,
                            const std::shared_ptr<IKeyboard> keyboard );
 
       void ReadInput() override;

--- a/ConsoleGame/PlayingStateConsoleRenderer.cpp
+++ b/ConsoleGame/PlayingStateConsoleRenderer.cpp
@@ -1,6 +1,6 @@
 #include "PlayingStateConsoleRenderer.h"
 #include "IConsoleDrawer.h"
-#include "GameRenderConfig.h"
+#include "ConsoleRenderConfig.h"
 #include "GameConfig.h"
 #include "IPlayerInfoProvider.h"
 #include "ConsoleColor.h"
@@ -12,7 +12,7 @@ using namespace std;
 using namespace ConsoleGame;
 
 PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<IConsoleDrawer> consoleDrawer,
-                                                          const shared_ptr<GameRenderConfig> renderConfig,
+                                                          const shared_ptr<ConsoleRenderConfig> renderConfig,
                                                           const shared_ptr<GameConfig> gameConfig,
                                                           const shared_ptr<IPlayerInfoProvider> playerInfoProvider )
    : _consoleDrawer( consoleDrawer ),

--- a/ConsoleGame/PlayingStateConsoleRenderer.h
+++ b/ConsoleGame/PlayingStateConsoleRenderer.h
@@ -7,7 +7,7 @@
 namespace ConsoleGame
 {
    class IConsoleDrawer;
-   class GameRenderConfig;
+   class ConsoleRenderConfig;
    class GameConfig;
    class IPlayerInfoProvider;
 
@@ -15,7 +15,7 @@ namespace ConsoleGame
    {
    public:
       PlayingStateConsoleRenderer( const std::shared_ptr<IConsoleDrawer> consoleDrawer,
-                                   const std::shared_ptr<GameRenderConfig> renderConfig,
+                                   const std::shared_ptr<ConsoleRenderConfig> renderConfig,
                                    const std::shared_ptr<GameConfig> gameConfig,
                                    const std::shared_ptr<IPlayerInfoProvider> playerInfoProvider );
 
@@ -26,7 +26,7 @@ namespace ConsoleGame
 
    private:
       const std::shared_ptr<IConsoleDrawer> _consoleDrawer;
-      const std::shared_ptr<GameRenderConfig> _renderConfig;
+      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
       const std::shared_ptr<GameConfig> _gameConfig;
       const std::shared_ptr<IPlayerInfoProvider> _playerInfoProvider;
    };

--- a/ConsoleGame/StartupStateConsoleRenderer.cpp
+++ b/ConsoleGame/StartupStateConsoleRenderer.cpp
@@ -4,7 +4,7 @@
 #include "StartupStateConsoleRenderer.h"
 #include "IConsoleDrawer.h"
 #include "ConsoleRenderConfig.h"
-#include "GameInputConfig.h"
+#include "KeyboardInputConfig.h"
 #include "ConsoleColor.h"
 
 using namespace std;
@@ -12,7 +12,7 @@ using namespace ConsoleGame;
 
 StartupStateConsoleRenderer::StartupStateConsoleRenderer( const shared_ptr<IConsoleDrawer> consoleDrawer,
                                                           const shared_ptr<ConsoleRenderConfig> renderConfig,
-                                                          const shared_ptr<GameInputConfig> inputConfig )
+                                                          const shared_ptr<KeyboardInputConfig> inputConfig )
    : _consoleDrawer( consoleDrawer ),
      _renderConfig( renderConfig ),
      _inputConfig( inputConfig )

--- a/ConsoleGame/StartupStateConsoleRenderer.cpp
+++ b/ConsoleGame/StartupStateConsoleRenderer.cpp
@@ -3,7 +3,7 @@
 
 #include "StartupStateConsoleRenderer.h"
 #include "IConsoleDrawer.h"
-#include "GameRenderConfig.h"
+#include "ConsoleRenderConfig.h"
 #include "GameInputConfig.h"
 #include "ConsoleColor.h"
 
@@ -11,7 +11,7 @@ using namespace std;
 using namespace ConsoleGame;
 
 StartupStateConsoleRenderer::StartupStateConsoleRenderer( const shared_ptr<IConsoleDrawer> consoleDrawer,
-                                                          const shared_ptr<GameRenderConfig> renderConfig,
+                                                          const shared_ptr<ConsoleRenderConfig> renderConfig,
                                                           const shared_ptr<GameInputConfig> inputConfig )
    : _consoleDrawer( consoleDrawer ),
      _renderConfig( renderConfig ),

--- a/ConsoleGame/StartupStateConsoleRenderer.h
+++ b/ConsoleGame/StartupStateConsoleRenderer.h
@@ -8,14 +8,14 @@ namespace ConsoleGame
 {
    class IConsoleDrawer;
    class ConsoleRenderConfig;
-   class GameInputConfig;
+   class KeyboardInputConfig;
 
    class StartupStateConsoleRenderer : public IGameRenderer
    {
    public:
       StartupStateConsoleRenderer( const std::shared_ptr<IConsoleDrawer> consoleDrawer,
                                    const std::shared_ptr<ConsoleRenderConfig> renderConfig,
-                                   const std::shared_ptr<GameInputConfig> inputConfig );
+                                   const std::shared_ptr<KeyboardInputConfig> inputConfig );
 
       void Render() override;
 
@@ -25,6 +25,6 @@ namespace ConsoleGame
    private:
       const std::shared_ptr<IConsoleDrawer> _consoleDrawer;
       const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
-      const std::shared_ptr<GameInputConfig> _inputConfig;
+      const std::shared_ptr<KeyboardInputConfig> _inputConfig;
    };
 }

--- a/ConsoleGame/StartupStateConsoleRenderer.h
+++ b/ConsoleGame/StartupStateConsoleRenderer.h
@@ -7,14 +7,14 @@
 namespace ConsoleGame
 {
    class IConsoleDrawer;
-   class GameRenderConfig;
+   class ConsoleRenderConfig;
    class GameInputConfig;
 
    class StartupStateConsoleRenderer : public IGameRenderer
    {
    public:
       StartupStateConsoleRenderer( const std::shared_ptr<IConsoleDrawer> consoleDrawer,
-                                   const std::shared_ptr<GameRenderConfig> renderConfig,
+                                   const std::shared_ptr<ConsoleRenderConfig> renderConfig,
                                    const std::shared_ptr<GameInputConfig> inputConfig );
 
       void Render() override;
@@ -24,7 +24,7 @@ namespace ConsoleGame
 
    private:
       const std::shared_ptr<IConsoleDrawer> _consoleDrawer;
-      const std::shared_ptr<GameRenderConfig> _renderConfig;
+      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
       const std::shared_ptr<GameInputConfig> _inputConfig;
    };
 }

--- a/ConsoleGameTests/GameConsoleRendererTests.cpp
+++ b/ConsoleGameTests/GameConsoleRendererTests.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include <ConsoleGame/GameConsoleRenderer.h>
-#include <ConsoleGame/GameRenderConfig.h>
+#include <ConsoleGame/ConsoleRenderConfig.h>
 #include <ConsoleGame/IConsoleDrawer.h>
 #include <ConsoleGame/IGameStateProvider.h>
 #include <ConsoleGame/GameEventAggregator.h>
@@ -24,7 +24,7 @@ class GameConsoleRendererTests : public Test
 public:
    void SetUp() override
    {
-      _renderConfig.reset( new GameRenderConfig );
+      _renderConfig.reset( new ConsoleRenderConfig );
       _consoleDrawerMock.reset( new NiceMock<mock_ConsoleDrawer> );
       _stateProviderMock.reset( new NiceMock<mock_GameStateProvider> );
       _diagnosticsRendererMock.reset( new NiceMock<mock_GameRenderer> );
@@ -49,7 +49,7 @@ public:
    }
 
 protected:
-   shared_ptr<GameRenderConfig> _renderConfig;
+   shared_ptr<ConsoleRenderConfig> _renderConfig;
    shared_ptr<mock_ConsoleDrawer> _consoleDrawerMock;
    shared_ptr<mock_GameStateProvider> _stateProviderMock;
    shared_ptr<mock_GameRenderer> _diagnosticsRendererMock;

--- a/ConsoleGameTests/KeyboardInputReaderTests.cpp
+++ b/ConsoleGameTests/KeyboardInputReaderTests.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include <ConsoleGame/KeyboardInputReader.h>
-#include <ConsoleGame/GameInputConfig.h>
+#include <ConsoleGame/KeyboardInputConfig.h>
 #include <ConsoleGame/KeyCode.h>
 #include <ConsoleGame/GameButton.h>
 
@@ -18,7 +18,7 @@ class KeyboardInputReaderTests : public Test
 public:
    void SetUp() override
    {
-      _inputConfig.reset( new GameInputConfig );
+      _inputConfig.reset( new KeyboardInputConfig );
       _keyboardMock.reset( new NiceMock<mock_Keyboard> );
    }
 
@@ -34,7 +34,7 @@ public:
    }
 
 protected:
-   shared_ptr<GameInputConfig> _inputConfig;
+   shared_ptr<KeyboardInputConfig> _inputConfig;
    shared_ptr<mock_Keyboard> _keyboardMock;
 
    shared_ptr<KeyboardInputReader> _inputReader;


### PR DESCRIPTION
In the interest of making it easier to set up a non-console renderer and a non-keyboard input reader, the config objects in `GameConfig` should also be generic, so I just set up an abstract `IGameRenderConfig` and `IGameInputConfig`, and now only the console-related classes take in the console-specific config, and likewise with keyboard-related classes.