### PR TITLE
Bugfix: The clock is not sleeping correctly

### DIFF
--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -125,6 +125,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -142,6 +143,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/ConsoleGame/GameClock.cpp
+++ b/ConsoleGame/GameClock.cpp
@@ -39,14 +39,14 @@ void GameClock::Tick()
       return;
    }
 
-   auto nowNano = _highResolutionClock->Now();
+   auto frameEndTimeNano = _highResolutionClock->Now();
 
-   auto elapsedFrameTimeNano = nowNano - _frameStartTimeNano;
+   auto elapsedFrameTimeNano = frameEndTimeNano - _frameStartTimeNano;
    auto remainingFrameTimeNano = _nanoSecondsPerFrame - elapsedFrameTimeNano;
 
    if ( remainingFrameTimeNano > 0ll )
    {
-      _sleeper->Sleep( (unsigned long)( remainingFrameTimeNano / 1'000'000 ) ); // Sleep() uses milliseconds
+      _sleeper->Sleep( remainingFrameTimeNano );
    }
    else if ( remainingFrameTimeNano < 0ll )
    {

--- a/ConsoleGame/GameConsoleRenderer.cpp
+++ b/ConsoleGame/GameConsoleRenderer.cpp
@@ -20,7 +20,8 @@ GameConsoleRenderer::GameConsoleRenderer( const shared_ptr<ConsoleRenderConfig> 
    : _consoleDrawer( consoleDrawer ),
      _stateProvider( stateProvider ),
      _diagnosticsRenderer( diagnosticsRenderer ),
-     _showDiagnostics( false )
+     _showDiagnostics( false ),
+     _isCleaningUp( false )
 {
    eventAggregator->RegisterEventHandler( GameEvent::Shutdown, std::bind( &GameConsoleRenderer::HandleQuitEvent, this ) );
    eventAggregator->RegisterEventHandler( GameEvent::ToggleDiagnostics, std::bind( &GameConsoleRenderer::HandleToggleDiagnosticsEvent, this ) );
@@ -37,6 +38,11 @@ void GameConsoleRenderer::AddRendererForGameState( GameState state, shared_ptr<I
 
 void GameConsoleRenderer::Render()
 {
+   if ( _isCleaningUp )
+   {
+      return;
+   }
+
    _consoleDrawer->ClearDrawBuffer();
 
    _stateRenderers.at( _stateProvider->GetGameState() )->Render();
@@ -49,8 +55,9 @@ void GameConsoleRenderer::Render()
    _consoleDrawer->FlipDrawBuffer();
 }
 
-void GameConsoleRenderer::HandleQuitEvent() const
+void GameConsoleRenderer::HandleQuitEvent()
 {
+   _isCleaningUp = true;
    _consoleDrawer->CleanUp();
 }
 

--- a/ConsoleGame/GameConsoleRenderer.cpp
+++ b/ConsoleGame/GameConsoleRenderer.cpp
@@ -39,12 +39,12 @@ void GameConsoleRenderer::Render()
 {
    _consoleDrawer->ClearDrawBuffer();
 
+   _stateRenderers.at( _stateProvider->GetGameState() )->Render();
+
    if ( _showDiagnostics )
    {
       _diagnosticsRenderer->Render();
    }
-
-   _stateRenderers.at( _stateProvider->GetGameState() )->Render();
 
    _consoleDrawer->FlipDrawBuffer();
 }

--- a/ConsoleGame/GameConsoleRenderer.h
+++ b/ConsoleGame/GameConsoleRenderer.h
@@ -29,7 +29,7 @@ namespace ConsoleGame
       void Render() override;
 
    private:
-      void HandleQuitEvent() const;
+      void HandleQuitEvent();
       void HandleToggleDiagnosticsEvent();
 
    private:
@@ -40,5 +40,6 @@ namespace ConsoleGame
       std::map<GameState, std::shared_ptr<IGameRenderer>> _stateRenderers;
 
       bool _showDiagnostics;
+      bool _isCleaningUp;
    };
 }

--- a/ConsoleGame/GameRunner.cpp
+++ b/ConsoleGame/GameRunner.cpp
@@ -26,8 +26,8 @@ void GameRunner::Run()
 
    while ( _isRunning )
    {
-      _renderer->Render();
       _inputHandler->HandleInput();
+      _renderer->Render();
       _clock->Tick();
    }
 

--- a/ConsoleGame/HighResolutionClockWrapper.cpp
+++ b/ConsoleGame/HighResolutionClockWrapper.cpp
@@ -7,5 +7,5 @@ using namespace ConsoleGame;
 
 long long HighResolutionClockWrapper::Now()
 {
-   return chrono::high_resolution_clock::now().time_since_epoch().count();
+   return chrono::steady_clock::now().time_since_epoch().count();
 }

--- a/ConsoleGame/HighResolutionClockWrapper.cpp
+++ b/ConsoleGame/HighResolutionClockWrapper.cpp
@@ -1,9 +1,25 @@
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <timeapi.h>
+
 #include <chrono>
 
 #include "HighResolutionClockWrapper.h"
 
 using namespace std;
 using namespace ConsoleGame;
+
+HighResolutionClockWrapper::HighResolutionClockWrapper()
+{
+   // According to documentation, this sets the system's minimum clock resolution to
+   // 1 millisecond. Without it, higher frame rates have unpredictable results in Windows.
+   timeBeginPeriod( 1 );
+}
+
+HighResolutionClockWrapper::~HighResolutionClockWrapper()
+{
+   timeEndPeriod( 1 );
+}
 
 long long HighResolutionClockWrapper::Now()
 {

--- a/ConsoleGame/HighResolutionClockWrapper.h
+++ b/ConsoleGame/HighResolutionClockWrapper.h
@@ -7,6 +7,9 @@ namespace ConsoleGame
    class HighResolutionClockWrapper : public IHighResolutionClock
    {
    public:
+      HighResolutionClockWrapper();
+      ~HighResolutionClockWrapper();
+
       long long Now() override;
    };
 }

--- a/ConsoleGame/ISleeper.h
+++ b/ConsoleGame/ISleeper.h
@@ -5,6 +5,6 @@ namespace ConsoleGame
    class __declspec( novtable ) ISleeper
    {
    public:
-      virtual void Sleep( unsigned long milliseconds ) = 0;
+      virtual void Sleep( long long nanoseconds ) = 0;
    };
 }

--- a/ConsoleGame/SleeperWrapper.cpp
+++ b/ConsoleGame/SleeperWrapper.cpp
@@ -1,11 +1,12 @@
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <chrono>
+#include <thread>
 
 #include "SleeperWrapper.h"
 
+using namespace std;
 using namespace ConsoleGame;
 
-void SleeperWrapper::Sleep( unsigned long milliseconds )
+void SleeperWrapper::Sleep( long long nanoseconds )
 {
-   ::Sleep( milliseconds );
+   this_thread::sleep_for( chrono::nanoseconds( nanoseconds ) );
 }

--- a/ConsoleGame/SleeperWrapper.h
+++ b/ConsoleGame/SleeperWrapper.h
@@ -7,6 +7,6 @@ namespace ConsoleGame
    class SleeperWrapper : public ISleeper
    {
    public:
-      void Sleep( unsigned long milliseconds ) override;
+      void Sleep( long long nanoseconds ) override;
    };
 }

--- a/ConsoleGameTests/GameClockTests.cpp
+++ b/ConsoleGameTests/GameClockTests.cpp
@@ -89,7 +89,7 @@ TEST_F( GameClockTests, Tick_TimeIsLeftInFrame_SleepsForRemainingTime )
 
    ON_CALL( *_highResolutionClockMock, Now() ).WillByDefault( Return( 1'000'000ll ) );
 
-   EXPECT_CALL( *_sleeperMock, Sleep( 9 ) );
+   EXPECT_CALL( *_sleeperMock, Sleep( 9'000'000ll ) );
 
    _gameClock->Tick();
 }

--- a/ConsoleGameTests/GameConsoleRendererTests.cpp
+++ b/ConsoleGameTests/GameConsoleRendererTests.cpp
@@ -71,7 +71,20 @@ TEST_F( GameConsoleRendererTests, Constructor_Always_InitializesConsoleDrawer )
    BuildRenderer();
 }
 
-TEST_F( GameConsoleRendererTests, Render_Always_ClearsConsoleDrawerBuffer )
+TEST_F( GameConsoleRendererTests, Render_IsCleaningUp_DoesNotRenderAnything )
+{
+   BuildRenderer();
+
+   _eventAggregator->RaiseEvent( GameEvent::Shutdown );
+
+   EXPECT_CALL( *_consoleDrawerMock, ClearDrawBuffer() ).Times( 0 );
+   EXPECT_CALL( *_startupStateRendererMock, Render() ).Times( 0 );
+   EXPECT_CALL( *_consoleDrawerMock, FlipDrawBuffer() ).Times( 0 );
+
+   _consoleRenderer->Render();
+}
+
+TEST_F( GameConsoleRendererTests, Render_IsNotCleaningUp_ClearsConsoleDrawerBuffer )
 {
    BuildRenderer();
 

--- a/ConsoleGameTests/mock_Sleeper.h
+++ b/ConsoleGameTests/mock_Sleeper.h
@@ -7,5 +7,5 @@
 class mock_Sleeper : public ConsoleGame::ISleeper
 {
 public:
-   MOCK_METHOD( void, Sleep, ( unsigned long ), ( override ) );
+   MOCK_METHOD( void, Sleep, ( long long ), ( override ) );
 };


### PR DESCRIPTION
This took some digging, and I refactored a few things along the way as I ran into them, but I think I have it working correctly now. I noticed even though the FPS was set to 60, it was acting more like 30. The frame count seemed to be incrementing by 60 frames every two seconds, and it got even worse the higher you set the FPS. I narrowed it down to the `Sleep` call, it wasn't being accurate at all. I switched from the Windows `Sleep` to the thread version of `std::this_thread::sleep_for`, which didn't fix the problem but I kept it because not only does it avoid `Windows.h`, but allows nanoseconds.

It turned out to be a Windows problem, I guess the clock is not too accurate when your minimum resolution is around 15ms or higher (not sure what the default is). Someone on Stack Overflow suggested increasing the resolution to the max, which is 1ms, by calling `timeBeginPeriod(1)` and `timeEndPeriod(1)` (docs here: https://learn.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod). I think it's mostly fixed now, although it MIGHT still be just a TINY bit slower than 60 fps. That could be in my head though, it's hard to judge timing.

Bonus things I changed along the way:

- I swapped the order of the calls to "handle input" and "render". Somehow it seems more correct to handle input first, then render the game, and then tick the clock.
- Because I swapped the input and render order, I had to add an `isCleaningUp` flag to the renderer. When shutting down, it would clean up the console drawer, but then still render the game because it didn't remember we're shutting down.
- I also swapped the order of the calls to "render game state" and "render diagnostics". Diagnostics should always be on top.