### PR TITLE
Refactor how the clock handles frames

### DIFF
--- a/ConsoleGame/GameClock.cpp
+++ b/ConsoleGame/GameClock.cpp
@@ -14,31 +14,16 @@ GameClock::GameClock( const shared_ptr<IHighResolutionClock> highResolutionClock
      _totalFrameCount( 0 ),
      _lagFrameCount( 0 ),
      _frameStartTimeNano(),
-     _nanoSecondsPerFrame( 1'000'000'000ll / framesPerSecond ),
-     _isRunning( false )
+     _nanoSecondsPerFrame( 1'000'000'000ll / framesPerSecond )
 { }
 
-void GameClock::Start()
+void GameClock::StartFrame()
 {
-   if ( _isRunning )
-   {
-      return;
-   }
-
-   _totalFrameCount = 0;
-   _lagFrameCount = 0;
-   _isRunning = true;
-
    _frameStartTimeNano = _highResolutionClock->Now();
 }
 
-void GameClock::Tick()
+void GameClock::WaitForNextFrame()
 {
-   if ( !_isRunning )
-   {
-      return;
-   }
-
    auto frameEndTimeNano = _highResolutionClock->Now();
 
    auto elapsedFrameTimeNano = frameEndTimeNano - _frameStartTimeNano;
@@ -54,10 +39,4 @@ void GameClock::Tick()
    }
 
    _totalFrameCount++;
-   _frameStartTimeNano = _highResolutionClock->Now();
-}
-
-void GameClock::Stop()
-{
-   _isRunning = false;
 }

--- a/ConsoleGame/GameClock.h
+++ b/ConsoleGame/GameClock.h
@@ -16,9 +16,8 @@ namespace ConsoleGame
                  const std::shared_ptr<ISleeper> sleeper,
                  int framesPerSecond );
 
-      void Start() override;
-      void Tick() override;
-      void Stop() override;
+      void StartFrame() override;
+      void WaitForNextFrame() override;
 
       int GetFramesPerSecond() const override { return _framesPerSecond; }
       long long GetTotalFrameCount() const override { return _totalFrameCount; }
@@ -33,6 +32,5 @@ namespace ConsoleGame
       long long _lagFrameCount;
       long long _frameStartTimeNano;
       long long _nanoSecondsPerFrame;
-      bool _isRunning;
    };
 }

--- a/ConsoleGame/GameRunner.cpp
+++ b/ConsoleGame/GameRunner.cpp
@@ -22,16 +22,15 @@ GameRunner::GameRunner( const std::shared_ptr<IGameEventAggregator> eventAggrega
 void GameRunner::Run()
 {
    _isRunning = true;
-   _clock->Start();
 
    while ( _isRunning )
    {
+      _clock->StartFrame();
       _inputHandler->HandleInput();
       _renderer->Render();
-      _clock->Tick();
+      _clock->WaitForNextFrame();
    }
 
-   _clock->Stop();
    _isRunning = false;
 }
 

--- a/ConsoleGame/IGameClock.h
+++ b/ConsoleGame/IGameClock.h
@@ -5,9 +5,8 @@ namespace ConsoleGame
    class __declspec( novtable ) IGameClock
    {
    public:
-      virtual void Start() = 0;
-      virtual void Tick() = 0;
-      virtual void Stop() = 0;
+      virtual void StartFrame() = 0;
+      virtual void WaitForNextFrame() = 0;
 
       virtual int GetFramesPerSecond() const = 0;
       virtual long long GetTotalFrameCount() const = 0;

--- a/ConsoleGameTests/mock_GameClock.h
+++ b/ConsoleGameTests/mock_GameClock.h
@@ -8,9 +8,8 @@
 class mock_GameClock : public ConsoleGame::IGameClock
 {
 public:
-   MOCK_METHOD( void, Start, ( ), ( override ) );
-   MOCK_METHOD( void, Tick, ( ), ( override ) );
-   MOCK_METHOD( void, Stop, ( ), ( override ) );
+   MOCK_METHOD( void, StartFrame, ( ), ( override ) );
+   MOCK_METHOD( void, WaitForNextFrame, ( ), ( override ) );
 
    MOCK_METHOD( int, GetFramesPerSecond, ( ), ( const, override ) );
    MOCK_METHOD( long long, GetTotalFrameCount, ( ), ( const, override ) );


### PR DESCRIPTION
It occurred to me that the clock isn't really set up properly, because it shouldn't have to know exactly when to set the frame start time (and it shouldn't be done at the end of the last frame anyway). We should be able to tell it when to start the timer for the frame, and then tell it when to wait for the frame to end. This doesn't really affect gameplay at the moment, but I could see it becoming a potential problem later, so it's better to address it now.