### PR TITLE
Calculate player movement based on frame rate

### DIFF
--- a/ConsoleGame/ArenaConfig.h
+++ b/ConsoleGame/ArenaConfig.h
@@ -5,10 +5,10 @@ namespace ConsoleGame
    class ArenaConfig
    {
    public:
-      int Width;
-      int Height;
+      double Width;
+      double Height;
 
-      int PlayerStartX;
-      int PlayerStartY;
+      double PlayerStartX;
+      double PlayerStartY;
    };
 }

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -60,7 +60,7 @@ int main()
    auto keyboardInputReader = shared_ptr<KeyboardInputReader>( new KeyboardInputReader( keyboardInputConfig, keyboard ) );
 
    // game data objects
-   auto playerFactory = shared_ptr<IPlayerFactory>( new PlayerFactory( config->PlayerConfig ) );
+   auto playerFactory = shared_ptr<IPlayerFactory>( new PlayerFactory( config ) );
    auto game = shared_ptr<Game>( new Game( config, eventAggregator, playerFactory ) );
 
    // input objects

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -231,14 +231,16 @@ shared_ptr<PlayerConfig> BuildPlayerConfig()
 {
    auto playerConfig = make_shared<PlayerConfig>();
 
-   playerConfig->StartVelocityX = 0;
-   playerConfig->StartVelocityY = 0;
+   playerConfig->StartVelocityX = 0.;
+   playerConfig->StartVelocityY = 0.;
 
-   playerConfig->MaxVelocityX = 30;
-   playerConfig->MaxVelocityY = 30;
+   // this means at max velocity, it should take
+   // 3 seconds to cross the arena horizontally
+   playerConfig->MaxVelocity = 1444.;
 
-   playerConfig->VelocityDeltaX = 1;
-   playerConfig->VelocityDeltaY = 1;
+   // this means it should take a third of a second
+   // to go from 0 to max velocity
+   playerConfig->AccelerationPerSecond = 4332.;
 
    playerConfig->StartDirection = Direction::Right;
 
@@ -249,11 +251,11 @@ shared_ptr<ArenaConfig> BuildArenaConfig()
 {
    auto arenaConfig = make_shared<ArenaConfig>();
 
-   arenaConfig->Width = 4332;
-   arenaConfig->Height = 1872;
+   arenaConfig->Width = 4332.;
+   arenaConfig->Height = 1872.;
 
-   arenaConfig->PlayerStartX = arenaConfig->Width / 2;
-   arenaConfig->PlayerStartY = arenaConfig->Height / 2;
+   arenaConfig->PlayerStartX = arenaConfig->Width / 2.;
+   arenaConfig->PlayerStartY = arenaConfig->Height / 2.;
 
    return arenaConfig;
 }

--- a/ConsoleGame/Game.cpp
+++ b/ConsoleGame/Game.cpp
@@ -77,15 +77,15 @@ Direction Game::GetPlayerDirection() const
 
 bool Game::IsPlayerMoving() const
 {
-   return _player->GetVelocityX() != 0 || _player->GetVelocityY() != 0;
+   return _player->GetVelocityX() != 0. || _player->GetVelocityY() != 0.;
 }
 
-int Game::GetArenaWidth() const
+double Game::GetArenaWidth() const
 {
    return _config->ArenaConfig->Width;
 }
 
-int Game::GetArenaHeight() const
+double Game::GetArenaHeight() const
 {
    return _config->ArenaConfig->Height;
 }
@@ -106,29 +106,29 @@ void Game::PushPlayer( Direction direction )
 
 void Game::MovePlayer()
 {
-   _arenaPlayerPositionX += _player->GetVelocityX();
+   _arenaPlayerPositionX += ( _player->GetVelocityX() / _config->FramesPerSecond );
 
-   if ( _arenaPlayerPositionX < 0 )
+   if ( _arenaPlayerPositionX < 0. )
    {
-      _arenaPlayerPositionX = 0;
+      _arenaPlayerPositionX = 0.;
       _player->StopX();
    }
    else if ( _arenaPlayerPositionX >= _config->ArenaConfig->Width )
    {
-      _arenaPlayerPositionX = _config->ArenaConfig->Width - 1;
+      _arenaPlayerPositionX = _config->ArenaConfig->Width - 1.;
       _player->StopX();
    }
 
-   _arenaPlayerPositionY += _player->GetVelocityY();
+   _arenaPlayerPositionY += ( _player->GetVelocityY() / _config->FramesPerSecond );
 
-   if ( _arenaPlayerPositionY < 0 )
+   if ( _arenaPlayerPositionY < 0. )
    {
-      _arenaPlayerPositionY = 0;
+      _arenaPlayerPositionY = 0.;
       _player->StopY();
    }
    else if ( _arenaPlayerPositionY >= _config->ArenaConfig->Height )
    {
-      _arenaPlayerPositionY = _config->ArenaConfig->Height - 1;
+      _arenaPlayerPositionY = _config->ArenaConfig->Height - 1.;
       _player->StopY();
    }
 }

--- a/ConsoleGame/Game.h
+++ b/ConsoleGame/Game.h
@@ -33,11 +33,11 @@ namespace ConsoleGame
       Direction GetPlayerDirection() const override;
       bool IsPlayerMoving() const override;
 
-      int GetArenaWidth() const override;
-      int GetArenaHeight() const override;
+      double GetArenaWidth() const override;
+      double GetArenaHeight() const override;
 
-      int GetArenaPlayerXPosition() const override { return _arenaPlayerPositionX; }
-      int GetArenaPlayerYPosition() const override { return _arenaPlayerPositionY; }
+      double GetArenaPlayerXPosition() const override { return _arenaPlayerPositionX; }
+      double GetArenaPlayerYPosition() const override { return _arenaPlayerPositionY; }
 
    private:
       void PushPlayer( Direction direction );
@@ -50,8 +50,8 @@ namespace ConsoleGame
 
       GameState _state;
 
-      int _arenaPlayerPositionX;
-      int _arenaPlayerPositionY;
+      double _arenaPlayerPositionX;
+      double _arenaPlayerPositionY;
 
       bool _playerWasPushedX;
       bool _playerWasPushedY;

--- a/ConsoleGame/IGameInfoProvider.h
+++ b/ConsoleGame/IGameInfoProvider.h
@@ -13,10 +13,10 @@ namespace ConsoleGame
       virtual Direction GetPlayerDirection() const = 0;
       virtual bool IsPlayerMoving() const = 0;
 
-      virtual int GetArenaWidth() const = 0;
-      virtual int GetArenaHeight() const = 0;
+      virtual double GetArenaWidth() const = 0;
+      virtual double GetArenaHeight() const = 0;
 
-      virtual int GetArenaPlayerXPosition() const = 0;
-      virtual int GetArenaPlayerYPosition() const = 0;
+      virtual double GetArenaPlayerXPosition() const = 0;
+      virtual double GetArenaPlayerYPosition() const = 0;
    };
 }

--- a/ConsoleGame/IPlayer.h
+++ b/ConsoleGame/IPlayer.h
@@ -13,8 +13,8 @@ namespace ConsoleGame
       virtual void StopX() = 0;
       virtual void StopY() = 0;
 
-      virtual int GetVelocityX() const = 0;
-      virtual int GetVelocityY() const = 0;
+      virtual double GetVelocityX() const = 0;
+      virtual double GetVelocityY() const = 0;
 
       virtual Direction GetDirection() const = 0;
    };

--- a/ConsoleGame/Player.cpp
+++ b/ConsoleGame/Player.cpp
@@ -9,9 +9,9 @@ using namespace ConsoleGame;
 Player::Player( const shared_ptr<PlayerConfig> config,
                 int framesPerSecond ) :
    _config( config ),
-   _framesPerSecond( framesPerSecond ),
    _velocityX( _config->StartVelocityX ),
    _velocityY( _config->StartVelocityY ),
+   _velocityDelta( _config->AccelerationPerSecond / framesPerSecond ),
    _direction( _config->StartDirection )
 {
 }
@@ -23,32 +23,32 @@ void Player::Push( Direction direction )
    switch ( direction )
    {
    case Direction::Left:
-      _velocityX -= _config->VelocityDeltaX;
+      _velocityX -= _velocityDelta;
       break;
    case Direction::UpLeft:
-      _velocityX -= _config->VelocityDeltaX;
-      _velocityY -= _config->VelocityDeltaY;
+      _velocityX -= _velocityDelta;
+      _velocityY -= _velocityDelta;
       break;
    case Direction::Up:
-      _velocityY -= _config->VelocityDeltaY;
+      _velocityY -= _velocityDelta;
       break;
    case Direction::UpRight:
-      _velocityX += _config->VelocityDeltaX;
-      _velocityY -= _config->VelocityDeltaY;
+      _velocityX += _velocityDelta;
+      _velocityY -= _velocityDelta;
       break;
    case Direction::Right:
-      _velocityX += _config->VelocityDeltaX;
+      _velocityX += _velocityDelta;
       break;
    case Direction::DownRight:
-      _velocityX += _config->VelocityDeltaX;
-      _velocityY += _config->VelocityDeltaY;
+      _velocityX += _velocityDelta;
+      _velocityY += _velocityDelta;
       break;
    case Direction::Down:
-      _velocityY += _config->VelocityDeltaY;
+      _velocityY += _velocityDelta;
       break;
    case Direction::DownLeft:
-      _velocityX -= _config->VelocityDeltaX;
-      _velocityY += _config->VelocityDeltaY;
+      _velocityX -= _velocityDelta;
+      _velocityY += _velocityDelta;
       break;
    }
 
@@ -57,55 +57,55 @@ void Player::Push( Direction direction )
 
 void Player::ApplyFrictionX()
 {
-   if ( _velocityX < 0 )
+   if ( _velocityX < 0. )
    {
-      _velocityX = min( _velocityX + _config->VelocityDeltaX, 0 );
+      _velocityX = min( _velocityX + _velocityDelta, 0. );
    }
-   else if ( _velocityX > 0 )
+   else if ( _velocityX > 0. )
    {
-      _velocityX = max( _velocityX - _config->VelocityDeltaX, 0 );
+      _velocityX = max( _velocityX - _velocityDelta, 0. );
    }
 }
 
 void Player::ApplyFrictionY()
 {
-   if ( _velocityY < 0 )
+   if ( _velocityY < 0. )
    {
-      _velocityY = min( _velocityY + _config->VelocityDeltaY, 0 );
+      _velocityY = min( _velocityY + _velocityDelta, 0. );
    }
-   else if ( _velocityY > 0 )
+   else if ( _velocityY > 0. )
    {
-      _velocityY = max( _velocityY - _config->VelocityDeltaY, 0 );
+      _velocityY = max( _velocityY - _velocityDelta, 0. );
    }
 }
 
 void Player::StopX()
 {
-   _velocityX = 0;
+   _velocityX = 0.;
 }
 
 void Player::StopY()
 {
-   _velocityY = 0;
+   _velocityY = 0.;
 }
 
 void Player::ClampVelocity()
 {
-   if ( _velocityX < -( _config->MaxVelocityX ) )
+   if ( _velocityX < -( _config->MaxVelocity ) )
    {
-      _velocityX = -( _config->MaxVelocityX );
+      _velocityX = -( _config->MaxVelocity );
    }
-   else if ( _velocityX > _config->MaxVelocityX )
+   else if ( _velocityX > _config->MaxVelocity )
    {
-      _velocityX = _config->MaxVelocityX;
+      _velocityX = _config->MaxVelocity;
    }
 
-   if ( _velocityY < -( _config->MaxVelocityY ) )
+   if ( _velocityY < -( _config->MaxVelocity ) )
    {
-      _velocityY = -( _config->MaxVelocityY );
+      _velocityY = -( _config->MaxVelocity );
    }
-   else if ( _velocityY > _config->MaxVelocityY )
+   else if ( _velocityY > _config->MaxVelocity )
    {
-      _velocityY = _config->MaxVelocityY;
+      _velocityY = _config->MaxVelocity;
    }
 }

--- a/ConsoleGame/Player.cpp
+++ b/ConsoleGame/Player.cpp
@@ -6,11 +6,13 @@
 using namespace std;
 using namespace ConsoleGame;
 
-Player::Player( const shared_ptr<PlayerConfig> config ) :
+Player::Player( const shared_ptr<PlayerConfig> config,
+                int framesPerSecond ) :
    _config( config ),
-   _velocityX( config->StartVelocityX ),
-   _velocityY( config->StartVelocityY ),
-   _direction( config->StartDirection )
+   _framesPerSecond( framesPerSecond ),
+   _velocityX( _config->StartVelocityX ),
+   _velocityY( _config->StartVelocityY ),
+   _direction( _config->StartDirection )
 {
 }
 

--- a/ConsoleGame/Player.h
+++ b/ConsoleGame/Player.h
@@ -20,8 +20,8 @@ namespace ConsoleGame
       void StopX() override;
       void StopY() override;
 
-      int GetVelocityX() const override { return _velocityX; }
-      int GetVelocityY() const override { return _velocityY; }
+      double GetVelocityX() const override { return _velocityX; }
+      double GetVelocityY() const override { return _velocityY; }
 
       Direction GetDirection() const override { return _direction; }
 
@@ -30,10 +30,11 @@ namespace ConsoleGame
 
    private:
       const std::shared_ptr<PlayerConfig> _config;
-      int _framesPerSecond;
 
-      int _velocityX;
-      int _velocityY;
+      double _velocityX;
+      double _velocityY;
+
+      double _velocityDelta;
 
       Direction _direction;
    };

--- a/ConsoleGame/Player.h
+++ b/ConsoleGame/Player.h
@@ -11,7 +11,8 @@ namespace ConsoleGame
    class Player : public IPlayer
    {
    public:
-      Player( const std::shared_ptr<PlayerConfig> config );
+      Player( const std::shared_ptr<PlayerConfig> config,
+              int framesPerSecond );
 
       void Push( Direction direction ) override;
       void ApplyFrictionX() override;
@@ -29,6 +30,7 @@ namespace ConsoleGame
 
    private:
       const std::shared_ptr<PlayerConfig> _config;
+      int _framesPerSecond;
 
       int _velocityX;
       int _velocityY;

--- a/ConsoleGame/PlayerConfig.h
+++ b/ConsoleGame/PlayerConfig.h
@@ -7,14 +7,12 @@ namespace ConsoleGame
    class PlayerConfig
    {
    public:
-      int StartVelocityX;
-      int StartVelocityY;
+      double StartVelocityX;
+      double StartVelocityY;
 
-      int MaxVelocityX;
-      int MaxVelocityY;
+      double MaxVelocity;
 
-      int VelocityDeltaX;
-      int VelocityDeltaY;
+      double AccelerationPerSecond;
 
       Direction StartDirection;
    };

--- a/ConsoleGame/PlayerFactory.cpp
+++ b/ConsoleGame/PlayerFactory.cpp
@@ -1,16 +1,16 @@
 #include "PlayerFactory.h"
 #include "Player.h"
-#include "PlayerConfig.h"
+#include "GameConfig.h"
 
 using namespace std;
 using namespace ConsoleGame;
 
-PlayerFactory::PlayerFactory( const shared_ptr<PlayerConfig> config ) :
+PlayerFactory::PlayerFactory( const shared_ptr<GameConfig> config ) :
    _config( config )
 {
 }
 
 const shared_ptr<IPlayer> PlayerFactory::CreatePlayer() const
 {
-   return shared_ptr<IPlayer>( new Player( _config ) );
+   return shared_ptr<IPlayer>( new Player( _config->PlayerConfig, _config->FramesPerSecond ) );
 }

--- a/ConsoleGame/PlayerFactory.h
+++ b/ConsoleGame/PlayerFactory.h
@@ -6,16 +6,16 @@
 
 namespace ConsoleGame
 {
-   class PlayerConfig;
+   class GameConfig;
 
    class PlayerFactory : public IPlayerFactory
    {
    public:
-      PlayerFactory( const std::shared_ptr<PlayerConfig> config );
+      PlayerFactory( const std::shared_ptr<GameConfig> config );
 
       const std::shared_ptr<IPlayer> CreatePlayer() const override;
 
    private:
-      const std::shared_ptr<PlayerConfig> _config;
+      const std::shared_ptr<GameConfig> _config;
    };
 }

--- a/ConsoleGame/PlayingStateConsoleRenderer.cpp
+++ b/ConsoleGame/PlayingStateConsoleRenderer.cpp
@@ -16,8 +16,8 @@ PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<ICons
    _consoleBuffer( consoleBuffer ),
    _renderConfig( renderConfig ),
    _gameInfoProvider( gameInfoProvider ),
-   _arenaCoordConverterX( renderConfig->ArenaCharWidth / (double)gameInfoProvider->GetArenaWidth() ),
-   _arenaCoordConverterY( renderConfig->ArenaCharHeight / (double)gameInfoProvider->GetArenaHeight() )
+   _arenaCoordConverterX( renderConfig->ArenaCharWidth / gameInfoProvider->GetArenaWidth() ),
+   _arenaCoordConverterY( renderConfig->ArenaCharHeight / gameInfoProvider->GetArenaHeight() )
 {
 }
 

--- a/ConsoleGameTests/GameTests.cpp
+++ b/ConsoleGameTests/GameTests.cpp
@@ -32,10 +32,12 @@ public:
       _playerFactoryMock.reset( new NiceMock<mock_PlayerFactory> );
       _playerMock.reset( new NiceMock<mock_Player> );
 
-      _config->ArenaConfig->Width = 10;
-      _config->ArenaConfig->Height = 8;
-      _config->ArenaConfig->PlayerStartX = 5;
-      _config->ArenaConfig->PlayerStartY = 4;
+      _config->ArenaConfig->Width = 1000.;
+      _config->ArenaConfig->Height = 800.;
+      _config->ArenaConfig->PlayerStartX = 500.;
+      _config->ArenaConfig->PlayerStartY = 400.;
+
+      _config->FramesPerSecond = 100;
 
       ON_CALL( *_playerFactoryMock, CreatePlayer() ).WillByDefault( Return( _playerMock ) );
    }
@@ -63,13 +65,13 @@ TEST_F( GameTests, Constructor_Always_SetsGameStateToStartup )
 
 TEST_F( GameTests, Constructor_Always_SetsPlayerInfoBasedOnConfig )
 {
-   _config->ArenaConfig->PlayerStartX = 10;
-   _config->ArenaConfig->PlayerStartY = 20;
+   _config->ArenaConfig->PlayerStartX = 10.;
+   _config->ArenaConfig->PlayerStartY = 20.;
 
    BuildGame();
 
-   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 10 );
-   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 20 );
+   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 10. );
+   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 20. );
 }
 
 TEST_F( GameTests, ExecuteCommand_Start_SetsGameStateToPlaying )
@@ -111,8 +113,8 @@ TEST_F( GameTests, GetPlayerDirection_Always_GetsDirectionFromPlayer )
 
 TEST_F( GameTests, IsPlayerMoving_PlayerIsNotMoving_ReturnsFalse )
 {
-   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( 0 ) );
-   EXPECT_CALL( *_playerMock, GetVelocityY() ).WillOnce( Return( 0 ) );
+   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( 0. ) );
+   EXPECT_CALL( *_playerMock, GetVelocityY() ).WillOnce( Return( 0. ) );
 
    BuildGame();
 
@@ -121,7 +123,7 @@ TEST_F( GameTests, IsPlayerMoving_PlayerIsNotMoving_ReturnsFalse )
 
 TEST_F( GameTests, IsPlayerMoving_PlayerIsMovingHorizontally_ReturnsTrue )
 {
-   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( -1 ) );
+   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( -1. ) );
 
    BuildGame();
 
@@ -130,8 +132,8 @@ TEST_F( GameTests, IsPlayerMoving_PlayerIsMovingHorizontally_ReturnsTrue )
 
 TEST_F( GameTests, IsPlayerMoving_PlayerIsMovingVertically_ReturnsTrue )
 {
-   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( 0 ) );
-   EXPECT_CALL( *_playerMock, GetVelocityY() ).WillOnce( Return( 3 ) );
+   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( 0. ) );
+   EXPECT_CALL( *_playerMock, GetVelocityY() ).WillOnce( Return( 3. ) );
 
    BuildGame();
 
@@ -140,18 +142,18 @@ TEST_F( GameTests, IsPlayerMoving_PlayerIsMovingVertically_ReturnsTrue )
 
 TEST_F( GameTests, GetArenaWidth_Always_GetsArenaWidthFromConfig )
 {
-   _config->ArenaConfig->Width = 11;
+   _config->ArenaConfig->Width = 11.;
    BuildGame();
 
-   EXPECT_EQ( _game->GetArenaWidth(), 11 );
+   EXPECT_EQ( _game->GetArenaWidth(), 11. );
 }
 
 TEST_F( GameTests, GetArenaHeight_Always_GetsArenaHeightFromConfig )
 {
-   _config->ArenaConfig->Height = 12;
+   _config->ArenaConfig->Height = 12.;
    BuildGame();
 
-   EXPECT_EQ( _game->GetArenaHeight(), 12 );
+   EXPECT_EQ( _game->GetArenaHeight(), 12. );
 }
 
 TEST_F( GameTests, RunFrame_GameStateIsNotPlaying_DoesNotChangePlayerInfo )
@@ -196,51 +198,51 @@ TEST_F( GameTests, RunFrame_PlayerWasPushedVertically_DoesNotApplyYFriction )
 
 TEST_F( GameTests, RunFrame_PlayerIsMovingLeft_PlayerGetsMovedLeft )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -2 ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -200. ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 3 );
+   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 498. );
 }
 
 TEST_F( GameTests, RunFrame_PlayerIsMovingRight_PlayerGetsMovedRight )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 2 ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 200. ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 7 );
+   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 502. );
 }
 
 TEST_F( GameTests, RunFrame_PlayerIsMovingUp_PlayerGetsMovedUp )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -2 ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -200. ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 2 );
+   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 398. );
 }
 
 TEST_F( GameTests, RunFrame_PlayerIsMovingDown_PlayerGetsMovedDown )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 2 ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 200. ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 6 );
+   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 402. );
 }
 
 TEST_F( GameTests, RunFrame_PlayerHitsLeftWall_PlayerIsStoppedHorizontally )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -7 ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -70001. ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
@@ -248,12 +250,12 @@ TEST_F( GameTests, RunFrame_PlayerHitsLeftWall_PlayerIsStoppedHorizontally )
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 0 );
+   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 0. );
 }
 
 TEST_F( GameTests, RunFrame_PlayerHitsRightWall_PlayerIsStoppedHorizontally )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 5 ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 50001. ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
@@ -261,12 +263,12 @@ TEST_F( GameTests, RunFrame_PlayerHitsRightWall_PlayerIsStoppedHorizontally )
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 9 );
+   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 999. );
 }
 
 TEST_F( GameTests, RunFrame_PlayerHitsTopWall_PlayerIsStoppedVertically )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -11 ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -40001. ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
@@ -274,12 +276,12 @@ TEST_F( GameTests, RunFrame_PlayerHitsTopWall_PlayerIsStoppedVertically )
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 0 );
+   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 0. );
 }
 
 TEST_F( GameTests, RunFrame_PlayerHitsBottomWall_PlayerIsStoppedVertically )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 4 ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 40001. ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
@@ -287,5 +289,5 @@ TEST_F( GameTests, RunFrame_PlayerHitsBottomWall_PlayerIsStoppedVertically )
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 7 );
+   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 799. );
 }

--- a/ConsoleGameTests/Mock_GameInfoProvider.h
+++ b/ConsoleGameTests/Mock_GameInfoProvider.h
@@ -10,8 +10,8 @@ public:
    MOCK_METHOD( ConsoleGame::GameState, GetGameState, ( ), ( const, override ) );
    MOCK_METHOD( ConsoleGame::Direction, GetPlayerDirection, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsPlayerMoving, ( ), ( const, override ) );
-   MOCK_METHOD( int, GetArenaWidth, ( ), ( const, override ) );
-   MOCK_METHOD( int, GetArenaHeight, ( ), ( const, override ) );
-   MOCK_METHOD( int, GetArenaPlayerXPosition, ( ), ( const, override ) );
-   MOCK_METHOD( int, GetArenaPlayerYPosition, ( ), ( const, override ) );
+   MOCK_METHOD( double, GetArenaWidth, ( ), ( const, override ) );
+   MOCK_METHOD( double, GetArenaHeight, ( ), ( const, override ) );
+   MOCK_METHOD( double, GetArenaPlayerXPosition, ( ), ( const, override ) );
+   MOCK_METHOD( double, GetArenaPlayerYPosition, ( ), ( const, override ) );
 };

--- a/ConsoleGameTests/PlayerTests.cpp
+++ b/ConsoleGameTests/PlayerTests.cpp
@@ -16,12 +16,10 @@ public:
    {
       _config.reset( new PlayerConfig );
 
-      _config->StartVelocityX = 0;
-      _config->StartVelocityY = 0;
-      _config->MaxVelocityX = 10;
-      _config->MaxVelocityY = 10;
-      _config->VelocityDeltaX = 2;
-      _config->VelocityDeltaY = 2;
+      _config->StartVelocityX = 0.;
+      _config->StartVelocityY = 0.;
+      _config->MaxVelocity = 100.;
+      _config->AccelerationPerSecond = 200.;
       _config->StartDirection = Direction::Left;
 
       _framesPerSecond = 100;
@@ -41,13 +39,13 @@ protected:
 
 TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromConfig )
 {
-   _config->StartVelocityX = 1;
-   _config->StartVelocityY = 2;
+   _config->StartVelocityX = 100.;
+   _config->StartVelocityY = 200.;
    _config->StartDirection = Direction::Right;
    BuildPlayer();
 
-   EXPECT_EQ( _player->GetVelocityX(), 1 );
-   EXPECT_EQ( _player->GetVelocityY(), 2 );
+   EXPECT_EQ( _player->GetVelocityX(), 100. );
+   EXPECT_EQ( _player->GetVelocityY(), 200. );
    EXPECT_EQ( _player->GetDirection(), Direction::Right );
 }
 
@@ -67,7 +65,7 @@ TEST_F( PlayerTests, Push_LeftAndVelocityHasNotMaxedOut_DecreasesXVelocity )
 
    _player->Push( Direction::Left );
 
-   EXPECT_EQ( _player->GetVelocityX(), -2 );
+   EXPECT_EQ( _player->GetVelocityX(), -2. );
 }
 
 TEST_F( PlayerTests, Push_UpLeftAndVelocityHasNotMaxedOut_DecreasesXAndYVelocity )
@@ -76,8 +74,8 @@ TEST_F( PlayerTests, Push_UpLeftAndVelocityHasNotMaxedOut_DecreasesXAndYVelocity
 
    _player->Push( Direction::UpLeft );
 
-   EXPECT_EQ( _player->GetVelocityX(), -2 );
-   EXPECT_EQ( _player->GetVelocityY(), -2 );
+   EXPECT_EQ( _player->GetVelocityX(), -2. );
+   EXPECT_EQ( _player->GetVelocityY(), -2. );
 }
 
 TEST_F( PlayerTests, Push_UpAndVelocityHasNotMaxedOut_DecreasesYVelocity )
@@ -86,7 +84,7 @@ TEST_F( PlayerTests, Push_UpAndVelocityHasNotMaxedOut_DecreasesYVelocity )
 
    _player->Push( Direction::Up );
 
-   EXPECT_EQ( _player->GetVelocityY(), -2 );
+   EXPECT_EQ( _player->GetVelocityY(), -2. );
 }
 
 TEST_F( PlayerTests, Push_UpRightAndVelocityHasNotMaxedOut_IncreasesXVelocityAndDecreasesYVelocity )
@@ -95,8 +93,8 @@ TEST_F( PlayerTests, Push_UpRightAndVelocityHasNotMaxedOut_IncreasesXVelocityAnd
 
    _player->Push( Direction::UpRight );
 
-   EXPECT_EQ( _player->GetVelocityX(), 2 );
-   EXPECT_EQ( _player->GetVelocityY(), -2 );
+   EXPECT_EQ( _player->GetVelocityX(), 2. );
+   EXPECT_EQ( _player->GetVelocityY(), -2. );
 }
 
 TEST_F( PlayerTests, Push_RightAndVelocityHasNotMaxedOut_IncreasesXVelocity )
@@ -105,7 +103,7 @@ TEST_F( PlayerTests, Push_RightAndVelocityHasNotMaxedOut_IncreasesXVelocity )
 
    _player->Push( Direction::Right );
 
-   EXPECT_EQ( _player->GetVelocityX(), 2 );
+   EXPECT_EQ( _player->GetVelocityX(), 2. );
 }
 
 TEST_F( PlayerTests, Push_DownRightAndVelocityHasNotMaxedOut_IncreasesXAndYVelocity )
@@ -114,8 +112,8 @@ TEST_F( PlayerTests, Push_DownRightAndVelocityHasNotMaxedOut_IncreasesXAndYVeloc
 
    _player->Push( Direction::DownRight );
 
-   EXPECT_EQ( _player->GetVelocityX(), 2 );
-   EXPECT_EQ( _player->GetVelocityY(), 2 );
+   EXPECT_EQ( _player->GetVelocityX(), 2. );
+   EXPECT_EQ( _player->GetVelocityY(), 2. );
 }
 
 TEST_F( PlayerTests, Push_DownAndVelocityHasNotMaxedOut_IncreasesYVelocity )
@@ -124,7 +122,7 @@ TEST_F( PlayerTests, Push_DownAndVelocityHasNotMaxedOut_IncreasesYVelocity )
 
    _player->Push( Direction::Down );
 
-   EXPECT_EQ( _player->GetVelocityY(), 2 );
+   EXPECT_EQ( _player->GetVelocityY(), 2. );
 }
 
 TEST_F( PlayerTests, Push_DownLeftAndVelocityHasNotMaxedOut_DecreasesXVelocityAndIncreasesYVelocity )
@@ -133,48 +131,48 @@ TEST_F( PlayerTests, Push_DownLeftAndVelocityHasNotMaxedOut_DecreasesXVelocityAn
 
    _player->Push( Direction::DownLeft );
 
-   EXPECT_EQ( _player->GetVelocityX(), -2 );
-   EXPECT_EQ( _player->GetVelocityY(), 2 );
+   EXPECT_EQ( _player->GetVelocityX(), -2. );
+   EXPECT_EQ( _player->GetVelocityY(), 2. );
 }
 
 TEST_F( PlayerTests, Push_LeftAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _config->VelocityDeltaX = 11;
+   _config->AccelerationPerSecond = 100001.;
    BuildPlayer();
 
    _player->Push( Direction::Left );
 
-   EXPECT_EQ( _player->GetVelocityX(), -10 );
+   EXPECT_EQ( _player->GetVelocityX(), -100. );
 }
 
 TEST_F( PlayerTests, Push_RightAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _config->VelocityDeltaX = 11;
+   _config->AccelerationPerSecond = 100001.;
    BuildPlayer();
 
    _player->Push( Direction::Right );
 
-   EXPECT_EQ( _player->GetVelocityX(), 10 );
+   EXPECT_EQ( _player->GetVelocityX(), 100. );
 }
 
 TEST_F( PlayerTests, Push_UpAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _config->VelocityDeltaY = 11;
+   _config->AccelerationPerSecond = 10001.;
    BuildPlayer();
 
    _player->Push( Direction::Up );
 
-   EXPECT_EQ( _player->GetVelocityY(), -10 );
+   EXPECT_EQ( _player->GetVelocityY(), -100. );
 }
 
 TEST_F( PlayerTests, Push_DownAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _config->VelocityDeltaY = 11;
+   _config->AccelerationPerSecond = 10001.;
    BuildPlayer();
 
    _player->Push( Direction::Down );
 
-   EXPECT_EQ( _player->GetVelocityY(), 10 );
+   EXPECT_EQ( _player->GetVelocityY(), 100. );
 }
 
 TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingLeftAndHasVelocityToSpare_DoesNotStop )
@@ -185,7 +183,7 @@ TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingLeftAndHasVelocityToSpare_Does
    _player->Push( Direction::Left );
    _player->ApplyFrictionX();
 
-   EXPECT_EQ( _player->GetVelocityX(), -2 );
+   EXPECT_EQ( _player->GetVelocityX(), -2. );
 }
 
 TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingRightAndHasVelocityToSpare_DoesNotStop )
@@ -196,7 +194,7 @@ TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingRightAndHasVelocityToSpare_Doe
    _player->Push( Direction::Right );
    _player->ApplyFrictionX();
 
-   EXPECT_EQ( _player->GetVelocityX(), 2 );
+   EXPECT_EQ( _player->GetVelocityX(), 2. );
 }
 
 TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingUpAndHasVelocityToSpare_DoesNotStop )
@@ -207,7 +205,7 @@ TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingUpAndHasVelocityToSpare_DoesNo
    _player->Push( Direction::Up );
    _player->ApplyFrictionY();
 
-   EXPECT_EQ( _player->GetVelocityY(), -2 );
+   EXPECT_EQ( _player->GetVelocityY(), -2. );
 }
 
 TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingDownAndHasVelocityToSpare_DoesNotStop )
@@ -218,51 +216,51 @@ TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingDownAndHasVelocityToSpare_Does
    _player->Push( Direction::Down );
    _player->ApplyFrictionY();
 
-   EXPECT_EQ( _player->GetVelocityY(), 2 );
+   EXPECT_EQ( _player->GetVelocityY(), 2. );
 }
 
 TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingLeftAndHasNoVelocityToSpare_Stops )
 {
-   _config->StartVelocityX = -1;
-   _config->MaxVelocityX = 2;
+   _config->StartVelocityX = -1.;
+   _config->MaxVelocity = 2.;
    BuildPlayer();
 
    _player->ApplyFrictionX();
 
-   EXPECT_EQ( _player->GetVelocityX(), 0 );
+   EXPECT_EQ( _player->GetVelocityX(), 0. );
 }
 
 TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingRightAndHasNoVelocityToSpare_Stops )
 {
-   _config->StartVelocityX = 1;
-   _config->MaxVelocityX = 2;
+   _config->StartVelocityX = 1.;
+   _config->MaxVelocity = 2.;
    BuildPlayer();
 
    _player->ApplyFrictionX();
 
-   EXPECT_EQ( _player->GetVelocityX(), 0 );
+   EXPECT_EQ( _player->GetVelocityX(), 0. );
 }
 
 TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingUpAndHasNoVelocityToSpare_Stops )
 {
-   _config->StartVelocityY = -1;
-   _config->MaxVelocityY = 2;
+   _config->StartVelocityY = -1.;
+   _config->MaxVelocity = 2.;
    BuildPlayer();
 
    _player->ApplyFrictionY();
 
-   EXPECT_EQ( _player->GetVelocityY(), 0 );
+   EXPECT_EQ( _player->GetVelocityY(), 0. );
 }
 
 TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingDownAndHasNoVelocityToSpare_Stops )
 {
-   _config->StartVelocityY = 1;
-   _config->MaxVelocityY = 2;
+   _config->StartVelocityY = 1.;
+   _config->MaxVelocity = 2.;
    BuildPlayer();
 
    _player->ApplyFrictionY();
 
-   EXPECT_EQ( _player->GetVelocityY(), 0 );
+   EXPECT_EQ( _player->GetVelocityY(), 0. );
 }
 
 TEST_F( PlayerTests, StopX_Always_SetsXVelocityToZero )
@@ -272,7 +270,7 @@ TEST_F( PlayerTests, StopX_Always_SetsXVelocityToZero )
    _player->Push( Direction::Right );
    _player->StopX();
 
-   EXPECT_EQ( _player->GetVelocityX(), 0 );
+   EXPECT_EQ( _player->GetVelocityX(), 0. );
 }
 
 TEST_F( PlayerTests, StopY_Always_SetsYVelocityToZero )
@@ -282,5 +280,5 @@ TEST_F( PlayerTests, StopY_Always_SetsYVelocityToZero )
    _player->Push( Direction::Up );
    _player->StopY();
 
-   EXPECT_EQ( _player->GetVelocityY(), 0 );
+   EXPECT_EQ( _player->GetVelocityY(), 0. );
 }

--- a/ConsoleGameTests/PlayerTests.cpp
+++ b/ConsoleGameTests/PlayerTests.cpp
@@ -23,15 +23,18 @@ public:
       _config->VelocityDeltaX = 2;
       _config->VelocityDeltaY = 2;
       _config->StartDirection = Direction::Left;
+
+      _framesPerSecond = 100;
    }
 
    void BuildPlayer()
    {
-      _player.reset( new Player( _config ) );
+      _player.reset( new Player( _config, _framesPerSecond ) );
    }
 
 protected:
    shared_ptr<PlayerConfig> _config;
+   int _framesPerSecond;
 
    shared_ptr<Player> _player;
 };

--- a/ConsoleGameTests/mock_Player.h
+++ b/ConsoleGameTests/mock_Player.h
@@ -12,7 +12,7 @@ public:
    MOCK_METHOD( void, ApplyFrictionY, (), ( override ) );
    MOCK_METHOD( void, StopX, (), ( override ) );
    MOCK_METHOD( void, StopY, (), ( override ) );
-   MOCK_METHOD( int, GetVelocityX, ( ), ( const, override ) );
-   MOCK_METHOD( int, GetVelocityY, ( ), ( const, override ) );
+   MOCK_METHOD( double, GetVelocityX, ( ), ( const, override ) );
+   MOCK_METHOD( double, GetVelocityY, ( ), ( const, override ) );
    MOCK_METHOD( ConsoleGame::Direction, GetDirection, ( ), ( const, override ) );
 };


### PR DESCRIPTION
The idea here is to make it so the player's movements in real-time won't change if the frame rate ever changes, which means:

- The player's velocity should be calculated per-frame
- The player's acceleration should be calculated per-frame
- The distance the player moves in virtual space should be calculated per-frame

Essentially this just means all these values are now divided by the frame rate before being applied. The point is that now you can change `GameConfig.FramesPerSecond` without affecting the player's real-time movements.