### PR TITLE
Now targets Windows subsystem, creates its own console window on launch

### DIFF
--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -1,3 +1,4 @@
+#define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #include <io.h>
 #include <fcntl.h>
@@ -44,44 +45,37 @@ shared_ptr<KeyboardInputConfig> BuildKeyboardInputConfig();
 shared_ptr<PlayerConfig> BuildPlayerConfig();
 shared_ptr<ArenaConfig> BuildArenaConfig();
 shared_ptr<GameConfig> BuildGameConfig();
-int main();
+void LoadAndRun();
 
-INT WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow)
+INT WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow )
 {
-   CONSOLE_SCREEN_BUFFER_INFO consoleInfo;
-   int consoleHandleR, consoleHandleW ;
-   long stdioHandle;
    FILE *fptr;
 
    AllocConsole();
-   std::wstring strW = L"Dev Console";
-   SetConsoleTitle( strW.c_str() );
+   wstring consoleTitle = L"Console Game";
+   SetConsoleTitle( consoleTitle.c_str() );
 
-   EnableMenuItem(GetSystemMenu(GetConsoleWindow(), FALSE), SC_CLOSE , MF_GRAYED);
-   DrawMenuBar(GetConsoleWindow());
+   // you can't close this window unless I WANT you to
+   EnableMenuItem( GetSystemMenu( GetConsoleWindow(), FALSE ), SC_CLOSE , MF_GRAYED );
+   DrawMenuBar( GetConsoleWindow() );
 
-   GetConsoleScreenBufferInfo( GetStdHandle(STD_OUTPUT_HANDLE), &consoleInfo );
-
-   stdioHandle = (long)GetStdHandle( STD_INPUT_HANDLE );
-   consoleHandleR = _open_osfhandle( stdioHandle, _O_TEXT );
+   auto consoleHandleR = _open_osfhandle( (intptr_t)GetStdHandle( STD_INPUT_HANDLE ), _O_TEXT );
    fptr = _fdopen( consoleHandleR, "r" );
    *stdin = *fptr;
    setvbuf( stdin, NULL, _IONBF, 0 );
 
-   stdioHandle = (long) GetStdHandle( STD_OUTPUT_HANDLE );
-   consoleHandleW = _open_osfhandle( stdioHandle, _O_TEXT );
+   auto consoleHandleW = _open_osfhandle( (intptr_t)GetStdHandle( STD_OUTPUT_HANDLE ), _O_TEXT );
    fptr = _fdopen( consoleHandleW, "w" );
    *stdout = *fptr;
    setvbuf( stdout, NULL, _IONBF, 0 );
 
-   stdioHandle = (long)GetStdHandle( STD_ERROR_HANDLE );
    *stderr = *fptr;
    setvbuf( stderr, NULL, _IONBF, 0 );
 
-   main();
+   LoadAndRun();
 }
 
-int main()
+void LoadAndRun()
 {
    cout << "Loading all the things...";
 

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -1,3 +1,7 @@
+#include <Windows.h>
+#include <io.h>
+#include <fcntl.h>
+
 #include <iostream>
 
 #include "GameConfig.h"
@@ -40,6 +44,42 @@ shared_ptr<KeyboardInputConfig> BuildKeyboardInputConfig();
 shared_ptr<PlayerConfig> BuildPlayerConfig();
 shared_ptr<ArenaConfig> BuildArenaConfig();
 shared_ptr<GameConfig> BuildGameConfig();
+int main();
+
+INT WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow)
+{
+   CONSOLE_SCREEN_BUFFER_INFO consoleInfo;
+   int consoleHandleR, consoleHandleW ;
+   long stdioHandle;
+   FILE *fptr;
+
+   AllocConsole();
+   std::wstring strW = L"Dev Console";
+   SetConsoleTitle( strW.c_str() );
+
+   EnableMenuItem(GetSystemMenu(GetConsoleWindow(), FALSE), SC_CLOSE , MF_GRAYED);
+   DrawMenuBar(GetConsoleWindow());
+
+   GetConsoleScreenBufferInfo( GetStdHandle(STD_OUTPUT_HANDLE), &consoleInfo );
+
+   stdioHandle = (long)GetStdHandle( STD_INPUT_HANDLE );
+   consoleHandleR = _open_osfhandle( stdioHandle, _O_TEXT );
+   fptr = _fdopen( consoleHandleR, "r" );
+   *stdin = *fptr;
+   setvbuf( stdin, NULL, _IONBF, 0 );
+
+   stdioHandle = (long) GetStdHandle( STD_OUTPUT_HANDLE );
+   consoleHandleW = _open_osfhandle( stdioHandle, _O_TEXT );
+   fptr = _fdopen( consoleHandleW, "w" );
+   *stdout = *fptr;
+   setvbuf( stdout, NULL, _IONBF, 0 );
+
+   stdioHandle = (long)GetStdHandle( STD_ERROR_HANDLE );
+   *stderr = *fptr;
+   setvbuf( stderr, NULL, _IONBF, 0 );
+
+   main();
+}
 
 int main()
 {

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -123,7 +123,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -92,7 +92,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -108,7 +108,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -139,7 +139,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
Related to: #4 

## Overview

This means that we ALWAYS get a conhost window that we can control (specifically, resize!). If you F5 in VS, it'll launch the "Windows applicaiton," which creates no UI by default, so it's natural when it creates its own console window. Likewise, it behaves identically when running from Windows Terminal--a new conhost window is created, rather than running it directly in that Terminal tab.

I totally stole this from https://stackoverflow.com/a/5068479/13173054. I didn't look too closely at the options (e.g. the console title). Also, does this need a `FreeConsole` call to book-end `AllocConsole`? 😅 

## Demo

![console](https://user-images.githubusercontent.com/1928756/204100294-97807b09-5189-40f5-b09b-80363c00892d.gif)
