### PR TITLE
Refactored some console and startup code

### DIFF
--- a/ConsoleGame/ConsoleBuffer.cpp
+++ b/ConsoleGame/ConsoleBuffer.cpp
@@ -43,6 +43,13 @@ ConsoleBuffer::ConsoleBuffer( short defaultWidth, short defaultHeight ) :
    _originalColorAttribute = screenBufferInfo.wAttributes;
 
    ResetDrawBuffer();
+   SetCursorVisibility( false );
+
+   SetDefaultForegroundColor( _defaultForegroundColor );
+   SetDefaultBackgroundColor( _defaultBackgroundColor );
+
+   Clear();
+   Flip();
 }
 
 ConsoleBuffer::~ConsoleBuffer()
@@ -73,11 +80,6 @@ void ConsoleBuffer::LoadRenderConfig( const shared_ptr<IGameRenderConfig> config
 
    SMALL_RECT windowCoords{ 0, 0, _bufferInfo->ConsoleSize.X - 1, _bufferInfo->ConsoleSize.Y - 1 };
    SetConsoleWindowInfo( _bufferInfo->OutputHandle, TRUE, &windowCoords );
-
-   SetCursorVisibility( false );
-
-   SetDefaultForegroundColor( consoleConfig->DefaultForegroundColor );
-   SetDefaultBackgroundColor( consoleConfig->DefaultBackgroundColor );
 
    Clear();
    Flip();

--- a/ConsoleGame/ConsoleBuffer.cpp
+++ b/ConsoleGame/ConsoleBuffer.cpp
@@ -41,6 +41,9 @@ ConsoleBuffer::ConsoleBuffer( const shared_ptr<ConsoleRenderConfig> renderConfig
    GetConsoleScreenBufferInfo( _bufferInfo->OutputHandle, &screenBufferInfo );
    _originalColorAttribute = screenBufferInfo.wAttributes;
 
+   _originalConsoleWidth = ( screenBufferInfo.srWindow.Right - screenBufferInfo.srWindow.Left ) + 1;
+   _originalConsoleHeight = ( screenBufferInfo.srWindow.Bottom - screenBufferInfo.srWindow.Top ) + 1;
+
    for ( int i = 0; i < _bufferInfo->DrawBufferSize; i++ )
    {
       _bufferInfo->DrawBuffer[i] = CHAR_INFO();
@@ -70,13 +73,16 @@ void ConsoleBuffer::Initialize()
 
 void ConsoleBuffer::CleanUp()
 {
-   // TODO: restore the original console dimensions
    SetConsoleTextAttribute( _bufferInfo->OutputHandle, _originalColorAttribute );
-   Clear();
-   Flip();
+
+   SMALL_RECT windowCoords{ 0, 0, _originalConsoleWidth - 1, _originalConsoleHeight - 1 };
+   SetConsoleWindowInfo( _bufferInfo->OutputHandle, TRUE, &windowCoords );
 
    SetCursorVisibility( true );
    SetConsoleCursorPosition( _bufferInfo->OutputHandle, { 0, 0 } );
+
+   Clear();
+   Flip();
 }
 
 void ConsoleBuffer::SetDefaultForegroundColor( ConsoleColor color )

--- a/ConsoleGame/ConsoleBuffer.cpp
+++ b/ConsoleGame/ConsoleBuffer.cpp
@@ -37,6 +37,10 @@ ConsoleBuffer::ConsoleBuffer( const shared_ptr<ConsoleRenderConfig> renderConfig
    _bufferInfo->DrawBuffer = new CHAR_INFO[_bufferInfo->DrawBufferSize];
    _bufferInfo->OutputRect = { 0, 0, _renderConfig->ConsoleWidth, _renderConfig->ConsoleHeight };
 
+   CONSOLE_SCREEN_BUFFER_INFO screenBufferInfo;
+   GetConsoleScreenBufferInfo( _bufferInfo->OutputHandle, &screenBufferInfo );
+   _originalColorAttribute = screenBufferInfo.wAttributes;
+
    for ( int i = 0; i < _bufferInfo->DrawBufferSize; i++ )
    {
       _bufferInfo->DrawBuffer[i] = CHAR_INFO();
@@ -52,15 +56,8 @@ void ConsoleBuffer::Initialize()
 {
    SetConsoleScreenBufferSize( _bufferInfo->OutputHandle, { _bufferInfo->ConsoleSize.X, _bufferInfo->ConsoleSize.Y } );
 
-   // TODO: as of the Windows 11 update I installed on 11/09/2022,
-   // SetConsoleWindowInfo is no longer resizing the console window.
-   // I don't think this actually does anything as of that update,
-   // but hopefully it works for previous versions of Windows...
    SMALL_RECT windowCoords{ 0, 0, _bufferInfo->ConsoleSize.X - 1, _bufferInfo->ConsoleSize.Y - 1 };
    SetConsoleWindowInfo( _bufferInfo->OutputHandle, TRUE, &windowCoords );
-
-   // TODO: I tried this as well, it doesn't work either.
-   //system( format("MODE CON COLS={0} LINES={1}", _consoleSize.X, _consoleSize.Y ).c_str() );
 
    SetCursorVisibility( false );
 
@@ -73,10 +70,8 @@ void ConsoleBuffer::Initialize()
 
 void ConsoleBuffer::CleanUp()
 {
-   // TODO: restore the original console dimensions (not so easy, see above).
-   // also restore the original fg/bg colors, that should be easier.
-   SetDefaultForegroundColor( ConsoleColor::Grey );
-   SetDefaultBackgroundColor( ConsoleColor::Black );
+   // TODO: restore the original console dimensions
+   SetConsoleTextAttribute( _bufferInfo->OutputHandle, _originalColorAttribute );
    Clear();
    Flip();
 

--- a/ConsoleGame/ConsoleBuffer.h
+++ b/ConsoleGame/ConsoleBuffer.h
@@ -6,16 +6,15 @@
 
 namespace ConsoleGame
 {
-   class ConsoleRenderConfig;
    struct ConsoleBufferInfo;
 
    class ConsoleBuffer : public IConsoleBuffer
    {
    public:
-      ConsoleBuffer( const std::shared_ptr<ConsoleRenderConfig> renderConfig );
+      ConsoleBuffer( short defaultWidth, short defaultHeight );
       ~ConsoleBuffer();
 
-      void Initialize() override;
+      void LoadRenderConfig( const std::shared_ptr<IGameRenderConfig> renderConfig ) override;
       void CleanUp() override;
 
       void SetDefaultForegroundColor( ConsoleColor color ) override;
@@ -33,12 +32,11 @@ namespace ConsoleGame
       void Flip() override;
 
    private:
+      void ResetDrawBuffer();
       void SetCursorVisibility( bool isVisible );
       unsigned short ConsoleColorsToAttribute( ConsoleColor foregroundColor, ConsoleColor backgroundColor );
 
    private:
-      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
-
       std::shared_ptr<ConsoleBufferInfo> _bufferInfo;
 
       ConsoleColor _defaultForegroundColor;

--- a/ConsoleGame/ConsoleBuffer.h
+++ b/ConsoleGame/ConsoleBuffer.h
@@ -45,5 +45,7 @@ namespace ConsoleGame
       ConsoleColor _defaultBackgroundColor;
 
       unsigned short _originalColorAttribute;
+      short _originalConsoleWidth;
+      short _originalConsoleHeight;
    };
 }

--- a/ConsoleGame/ConsoleBuffer.h
+++ b/ConsoleGame/ConsoleBuffer.h
@@ -43,5 +43,7 @@ namespace ConsoleGame
 
       ConsoleColor _defaultForegroundColor;
       ConsoleColor _defaultBackgroundColor;
+
+      unsigned short _originalColorAttribute;
    };
 }

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -3,8 +3,6 @@
 #include <io.h>
 #include <fcntl.h>
 
-#include <iostream>
-
 #include "GameConfig.h"
 #include "ConsoleRenderConfig.h"
 #include "KeyboardInputConfig.h"

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -45,7 +45,7 @@ shared_ptr<KeyboardInputConfig> BuildKeyboardInputConfig();
 shared_ptr<PlayerConfig> BuildPlayerConfig();
 shared_ptr<ArenaConfig> BuildArenaConfig();
 shared_ptr<GameConfig> BuildGameConfig();
-void LoadAndRun();
+void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer );
 
 INT WINAPI WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ PSTR lpCmdLine, _In_ INT nCmdShow )
 {
@@ -70,10 +70,11 @@ INT WINAPI WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
    *stderr = *fptr;
    setvbuf( stderr, NULL, _IONBF, 0 );
 
-   LoadAndRun();
+   auto consoleBuffer = shared_ptr<ConsoleBuffer>( new ConsoleBuffer( 120, 30 ) );
+   LoadAndRun( consoleBuffer );
 }
 
-void LoadAndRun()
+void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 {
    // configs
    auto config = BuildGameConfig();
@@ -103,7 +104,6 @@ void LoadAndRun()
    inputHandler->AddInputHandlerForGameState( GameState::Playing, playingStateInputHandler );
 
    // rendering objects
-   auto consoleBuffer = shared_ptr<ConsoleBuffer>( new ConsoleBuffer( consoleRenderConfig ) );
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );
    auto startupStateConsoleRenderer = shared_ptr<StartupStateConsoleRenderer>( new StartupStateConsoleRenderer( consoleBuffer, consoleRenderConfig, keyboardInputConfig ) );
    auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, game ) );

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -74,6 +74,9 @@ INT WINAPI WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
 
 void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 {
+   consoleBuffer->Draw( 2, 1, "Loading all the things..." );
+   consoleBuffer->Flip();
+
    // configs
    auto config = BuildGameConfig();
    auto consoleRenderConfig = static_pointer_cast<ConsoleRenderConfig>( config->RenderConfig );

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -121,8 +121,6 @@ shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
 {
    auto renderConfig = make_shared<ConsoleRenderConfig>();
 
-   // TODO: don't change these dimensions until we figure out the issue with console resizing.
-   // (see ConsoleDrawer.cpp)
    renderConfig->ConsoleWidth = 120;
    renderConfig->ConsoleHeight = 30;
 

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -47,10 +47,8 @@ shared_ptr<ArenaConfig> BuildArenaConfig();
 shared_ptr<GameConfig> BuildGameConfig();
 void LoadAndRun();
 
-INT WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow )
+INT WINAPI WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ PSTR lpCmdLine, _In_ INT nCmdShow )
 {
-   FILE *fptr;
-
    AllocConsole();
    wstring consoleTitle = L"Console Game";
    SetConsoleTitle( consoleTitle.c_str() );
@@ -60,7 +58,7 @@ INT WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine
    DrawMenuBar( GetConsoleWindow() );
 
    auto consoleHandleR = _open_osfhandle( (intptr_t)GetStdHandle( STD_INPUT_HANDLE ), _O_TEXT );
-   fptr = _fdopen( consoleHandleR, "r" );
+   auto fptr = _fdopen( consoleHandleR, "r" );
    *stdin = *fptr;
    setvbuf( stdin, NULL, _IONBF, 0 );
 
@@ -77,8 +75,6 @@ INT WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine
 
 void LoadAndRun()
 {
-   cout << "Loading all the things...";
-
    // configs
    auto config = BuildGameConfig();
    auto consoleRenderConfig = static_pointer_cast<ConsoleRenderConfig>( config->RenderConfig );
@@ -118,11 +114,7 @@ void LoadAndRun()
    // game loop
    auto runner = shared_ptr<GameRunner>( new GameRunner( eventAggregator, clock, inputHandler, renderer, game, thread ) );
 
-   cout << " done!\nLet's goooo!\n";
-
    runner->Run();
-
-   cout << "Thanks for playing, enjoy your burrito!\n";
 }
 
 shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()

--- a/ConsoleGame/GameRenderer.cpp
+++ b/ConsoleGame/GameRenderer.cpp
@@ -26,7 +26,7 @@ GameRenderer::GameRenderer( const shared_ptr<ConsoleRenderConfig> renderConfig,
    eventAggregator->RegisterEventHandler( GameEvent::Shutdown, std::bind( &GameRenderer::HandleShutdownEvent, this ) );
    eventAggregator->RegisterEventHandler( GameEvent::ToggleDiagnostics, std::bind( &GameRenderer::HandleToggleDiagnosticsEvent, this ) );
 
-   _screenBuffer->Initialize();
+   _screenBuffer->LoadRenderConfig( renderConfig );
 }
 
 void GameRenderer::AddRendererForGameState( GameState state, shared_ptr<IGameRenderer> renderer )

--- a/ConsoleGame/IConsoleBuffer.h
+++ b/ConsoleGame/IConsoleBuffer.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <memory>
 
 #include "IScreenBuffer.h"
 

--- a/ConsoleGame/IConsoleBuffer.h
+++ b/ConsoleGame/IConsoleBuffer.h
@@ -13,7 +13,7 @@ namespace ConsoleGame
    class __declspec( novtable ) IConsoleBuffer : public IScreenBuffer
    {
    public:
-      virtual void Initialize() override = 0;
+      virtual void LoadRenderConfig( std::shared_ptr<IGameRenderConfig> config ) override = 0;
       virtual void CleanUp() override = 0;
 
       virtual void SetDefaultForegroundColor( ConsoleColor color ) = 0;

--- a/ConsoleGame/IScreenBuffer.h
+++ b/ConsoleGame/IScreenBuffer.h
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <memory>
+
 namespace ConsoleGame
 {
+   class IGameRenderConfig;
+
    class __declspec( novtable ) IScreenBuffer
    {
    public:
-      virtual void Initialize() = 0;
+      virtual void LoadRenderConfig( const std::shared_ptr<IGameRenderConfig> config ) = 0;
       virtual void CleanUp() = 0;
 
       virtual void Clear() = 0;

--- a/ConsoleGameTests/GameRendererTests.cpp
+++ b/ConsoleGameTests/GameRendererTests.cpp
@@ -59,9 +59,10 @@ protected:
    shared_ptr<GameRenderer> _renderer;
 };
 
-TEST_F( GameRendererTests, Constructor_Always_InitializesScreenBuffer )
+TEST_F( GameRendererTests, Constructor_Always_LoadsScreenBufferFromConfig )
 {
-   EXPECT_CALL( *_screenBufferMock, Initialize() );
+   auto baseConfig = static_pointer_cast<IGameRenderConfig>( _renderConfig );
+   EXPECT_CALL( *_screenBufferMock, LoadRenderConfig( baseConfig ) );
 
    BuildRenderer();
 }

--- a/ConsoleGameTests/mock_ScreenBuffer.h
+++ b/ConsoleGameTests/mock_ScreenBuffer.h
@@ -7,7 +7,7 @@
 class mock_ScreenBuffer : public ConsoleGame::IScreenBuffer
 {
 public:
-   MOCK_METHOD( void, Initialize, ( ), ( override ) );
+   MOCK_METHOD( void, LoadRenderConfig, ( const std::shared_ptr<ConsoleGame::IGameRenderConfig> ), ( override ) );
    MOCK_METHOD( void, CleanUp, ( ), ( override ) );
    MOCK_METHOD( void, Clear, ( ), ( override ) );
    MOCK_METHOD( void, Flip, ( ), ( override ) );


### PR DESCRIPTION
I think `ConsoleBuffer` could still use some more work to be more legible/flexible, but this is a start. Notable changes:

- `ConsoleBuffer`'s constructor now takes in default dimensions and initializes everything right out of the gate, so it's ready to use immediately.
- `WinMain` now creates the console buffer, and passes it to `LoadAndRun`. I figured it shouldn't be the game loader's responsibility to create the console, since `WinMain` is already doing a bunch of work related to that. Plus, this way we can write messages to the console during loading.
- `ConsoleBuffer`'s `Initialize` function is gone, in place of a more flexible `LoadRenderConfig` method.

I would love to move all the loading code into some kind of `GameLoader`, maybe that'll be next.