### PR TITLE
Turned on static analysis when building

### DIFF
--- a/ConsoleGame/ArenaConfig.h
+++ b/ConsoleGame/ArenaConfig.h
@@ -5,6 +5,12 @@ namespace ConsoleGame
    class ArenaConfig
    {
    public:
+      ArenaConfig() :
+         Width( 0 ),
+         Height( 0 ),
+         PlayerStartX( 0 ),
+         PlayerStartY( 0 ) { }
+
       double Width;
       double Height;
 

--- a/ConsoleGame/ConsoleBuffer.cpp
+++ b/ConsoleGame/ConsoleBuffer.cpp
@@ -13,6 +13,17 @@ namespace ConsoleGame
 {
    struct ConsoleBufferInfo
    {
+      ConsoleBufferInfo( HANDLE outputHandle,
+                         COORD consoleSize,
+                         int drawBufferSize,
+                         CHAR_INFO* drawBuffer,
+                         SMALL_RECT outputRect ) :
+         OutputHandle( outputHandle ),
+         ConsoleSize( consoleSize ),
+         DrawBufferSize( drawBufferSize ),
+         DrawBuffer( drawBuffer ),
+         OutputRect( outputRect ) { }
+
       HANDLE OutputHandle;
       COORD ConsoleSize;
       int DrawBufferSize;
@@ -31,12 +42,11 @@ ConsoleBuffer::ConsoleBuffer() :
    _originalWidth( 120 ),
    _originalHeight( 30 )
 {
-   _bufferInfo = shared_ptr<ConsoleBufferInfo>( new ConsoleBufferInfo );
-   _bufferInfo->OutputHandle = GetStdHandle( STD_OUTPUT_HANDLE );
-   _bufferInfo->ConsoleSize = { _originalWidth, _originalHeight };
-   _bufferInfo->DrawBufferSize = _originalWidth * _originalHeight;
-   _bufferInfo->DrawBuffer = new CHAR_INFO[_bufferInfo->DrawBufferSize];
-   _bufferInfo->OutputRect = { 0, 0, _originalWidth, _originalHeight };
+   _bufferInfo = shared_ptr<ConsoleBufferInfo>( new ConsoleBufferInfo( GetStdHandle( STD_OUTPUT_HANDLE ),
+                                                                       { _originalWidth, _originalHeight },
+                                                                       _originalWidth * _originalHeight,
+                                                                       new CHAR_INFO[(__int64)_originalWidth * (__int64)_originalHeight],
+                                                                       { 0, 0, _originalWidth, _originalHeight } ) );
 
    CONSOLE_SCREEN_BUFFER_INFO screenBufferInfo;
    GetConsoleScreenBufferInfo( _bufferInfo->OutputHandle, &screenBufferInfo );

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -78,9 +78,11 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/ConsoleGame/ConsoleRenderConfig.h
+++ b/ConsoleGame/ConsoleRenderConfig.h
@@ -13,6 +13,16 @@ namespace ConsoleGame
    class ConsoleRenderConfig : public IGameRenderConfig
    {
    public:
+      ConsoleRenderConfig() :
+         ConsoleWidth( 0 ),
+         ConsoleHeight( 0 ),
+         ArenaCharWidth( 0 ),
+         ArenaCharHeight( 0 ),
+         ArenaFenceX( 0 ),
+         ArenaFenceY( 0 ),
+         DefaultForegroundColor( (ConsoleColor)0 ),
+         DefaultBackgroundColor( (ConsoleColor)0 ) { }
+
       short ConsoleWidth;
       short ConsoleHeight;
 

--- a/ConsoleGame/ConsoleSprite.h
+++ b/ConsoleGame/ConsoleSprite.h
@@ -8,6 +8,10 @@ namespace ConsoleGame
 {
    struct ConsoleSprite
    {
+      ConsoleSprite() :
+         Width( 0 ),
+         Height( 0 ) { }
+
       int Width;
       int Height;
 

--- a/ConsoleGame/GameConfig.h
+++ b/ConsoleGame/GameConfig.h
@@ -13,6 +13,8 @@ namespace ConsoleGame
    class GameConfig
    {
    public:
+      GameConfig() : FramesPerSecond( 0 ) { }
+
       int FramesPerSecond;
 
       std::shared_ptr<IGameRenderConfig> RenderConfig;


### PR DESCRIPTION
Turns out there are a few "problems" with how I'm using structs and data classes, the static analyzer REALLY likes member variables to be initialized on construction.

Not really sure if this should stay on all the time for every build, because it increases compile time significantly, but for now let's see what happens.