### PR TITLE
Change "Config" object to "Defs" objects

### DIFF
--- a/ConsoleGame/ArenaDefs.h
+++ b/ConsoleGame/ArenaDefs.h
@@ -2,7 +2,7 @@
 
 namespace ConsoleGame
 {
-   class ArenaConfig
+   class ArenaDefs
    {
    public:
       double Width = 0.;

--- a/ConsoleGame/ConsoleBuffer.cpp
+++ b/ConsoleGame/ConsoleBuffer.cpp
@@ -4,7 +4,7 @@
 #include <format>
 
 #include "ConsoleBuffer.h"
-#include "ConsoleRenderConfig.h"
+#include "ConsoleRenderDefs.h"
 #include "ConsoleColor.h"
 #include "ConsoleSprite.h"
 #include "ConsolePixel.h"
@@ -72,14 +72,14 @@ void ConsoleBuffer::ResetDrawBuffer()
    }
 }
 
-void ConsoleBuffer::LoadRenderConfig( const shared_ptr<IGameRenderConfig> config )
+void ConsoleBuffer::LoadRenderDefs( const shared_ptr<IGameRenderDefs> renderDefs )
 {
-   auto consoleConfig = static_pointer_cast<ConsoleRenderConfig>( config );
+   auto consoleRenderDefs = static_pointer_cast<ConsoleRenderDefs>( renderDefs );
 
-   _bufferInfo->ConsoleSize = { consoleConfig->ConsoleWidth, consoleConfig->ConsoleHeight };
-   _bufferInfo->DrawBufferSize = consoleConfig->ConsoleWidth * consoleConfig->ConsoleHeight;
+   _bufferInfo->ConsoleSize = { consoleRenderDefs->ConsoleWidth, consoleRenderDefs->ConsoleHeight };
+   _bufferInfo->DrawBufferSize = consoleRenderDefs->ConsoleWidth * consoleRenderDefs->ConsoleHeight;
    _bufferInfo->DrawBuffer = new CHAR_INFO[_bufferInfo->DrawBufferSize];
-   _bufferInfo->OutputRect = { 0, 0, consoleConfig->ConsoleWidth, consoleConfig->ConsoleHeight };
+   _bufferInfo->OutputRect = { 0, 0, consoleRenderDefs->ConsoleWidth, consoleRenderDefs->ConsoleHeight };
 
    ResetDrawBuffer();
 
@@ -88,8 +88,8 @@ void ConsoleBuffer::LoadRenderConfig( const shared_ptr<IGameRenderConfig> config
    SMALL_RECT windowCoords{ 0, 0, _bufferInfo->ConsoleSize.X - 1, _bufferInfo->ConsoleSize.Y - 1 };
    SetConsoleWindowInfo( _bufferInfo->OutputHandle, TRUE, &windowCoords );
 
-   _defaultForegroundColor = consoleConfig->DefaultForegroundColor;
-   _defaultBackgroundColor = consoleConfig->DefaultBackgroundColor;
+   _defaultForegroundColor = consoleRenderDefs->DefaultForegroundColor;
+   _defaultBackgroundColor = consoleRenderDefs->DefaultBackgroundColor;
 
    Clear();
    Flip();

--- a/ConsoleGame/ConsoleBuffer.cpp
+++ b/ConsoleGame/ConsoleBuffer.cpp
@@ -5,9 +5,6 @@
 
 #include "ConsoleBuffer.h"
 #include "ConsoleRenderDefs.h"
-#include "ConsoleColor.h"
-#include "ConsoleSprite.h"
-#include "ConsolePixel.h"
 
 namespace ConsoleGame
 {

--- a/ConsoleGame/ConsoleBuffer.h
+++ b/ConsoleGame/ConsoleBuffer.h
@@ -14,7 +14,7 @@ namespace ConsoleGame
       ConsoleBuffer();
       ~ConsoleBuffer();
 
-      void LoadRenderConfig( const std::shared_ptr<IGameRenderConfig> renderConfig ) override;
+      void LoadRenderDefs( const std::shared_ptr<IGameRenderDefs> renderDefs ) override;
       void CleanUp() override;
 
       void SetDefaultForegroundColor( ConsoleColor color ) override;

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -5,7 +5,7 @@
 
 #include "GameConfig.h"
 #include "ConsoleRenderDefs.h"
-#include "KeyboardInputConfig.h"
+#include "KeyboardInputDefs.h"
 #include "PlayerConfig.h"
 #include "ArenaDefs.h"
 #include "KeyCode.h"
@@ -39,7 +39,7 @@ using namespace ConsoleGame;
 // but at the very least they should all have default values, and those could
 // probably be set in some initializer instead of in here.
 shared_ptr<ConsoleRenderDefs> BuildConsoleRenderDefs();
-shared_ptr<KeyboardInputConfig> BuildKeyboardInputConfig();
+shared_ptr<KeyboardInputDefs> BuildKeyboardInputDefs();
 shared_ptr<PlayerConfig> BuildPlayerConfig();
 shared_ptr<ArenaDefs> BuildArenaDefs();
 shared_ptr<GameConfig> BuildGameConfig();
@@ -80,7 +80,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    // configs
    auto config = BuildGameConfig();
    auto consoleRenderDefs = static_pointer_cast<ConsoleRenderDefs>( config->RenderDefs );
-   auto keyboardInputConfig = static_pointer_cast<KeyboardInputConfig>( config->InputConfig );
+   auto keyboardInputDefs = static_pointer_cast<KeyboardInputDefs>( config->InputDefs );
 
    // wrappers
    auto highResolutionClock = shared_ptr<HighResolutionClockWrapper>( new HighResolutionClockWrapper() );
@@ -91,7 +91,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    // auxiliary objects
    auto eventAggregator = shared_ptr<GameEventAggregator>( new GameEventAggregator() );
    auto clock = shared_ptr<GameClock>( new GameClock( highResolutionClock, sleeper, config->FramesPerSecond ) );
-   auto keyboardInputReader = shared_ptr<KeyboardInputReader>( new KeyboardInputReader( keyboardInputConfig, keyboard ) );
+   auto keyboardInputReader = shared_ptr<KeyboardInputReader>( new KeyboardInputReader( keyboardInputDefs, keyboard ) );
 
    // game data objects
    auto playerFactory = shared_ptr<IPlayerFactory>( new PlayerFactory( config ) );
@@ -106,7 +106,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 
    // rendering objects
    auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderDefs ) );
-   auto startupStateConsoleRenderer = shared_ptr<StartupStateConsoleRenderer>( new StartupStateConsoleRenderer( consoleBuffer, consoleRenderDefs, keyboardInputConfig ) );
+   auto startupStateConsoleRenderer = shared_ptr<StartupStateConsoleRenderer>( new StartupStateConsoleRenderer( consoleBuffer, consoleRenderDefs, keyboardInputDefs ) );
    auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderDefs, game ) );
    auto renderer = shared_ptr<GameRenderer>( new GameRenderer( consoleRenderDefs, consoleBuffer, game, diagnosticsRenderer, eventAggregator ) );
    renderer->AddRendererForGameState( GameState::Startup, startupStateConsoleRenderer );
@@ -189,69 +189,69 @@ shared_ptr<ConsoleRenderDefs> BuildConsoleRenderDefs()
    return renderDefs;
 }
 
-shared_ptr<KeyboardInputConfig> BuildKeyboardInputConfig()
+shared_ptr<KeyboardInputDefs> BuildKeyboardInputDefs()
 {
-   auto inputConfig = make_shared<KeyboardInputConfig>();
+   auto inputDefs = make_shared<KeyboardInputDefs>();
 
    // key code bindings
-   inputConfig->KeyMap[KeyCode::Left] = GameButton::Left;
-   inputConfig->KeyMap[KeyCode::Up] = GameButton::Up;
-   inputConfig->KeyMap[KeyCode::Right] = GameButton::Right;
-   inputConfig->KeyMap[KeyCode::Down] = GameButton::Down;
+   inputDefs->KeyMap[KeyCode::Left] = GameButton::Left;
+   inputDefs->KeyMap[KeyCode::Up] = GameButton::Up;
+   inputDefs->KeyMap[KeyCode::Right] = GameButton::Right;
+   inputDefs->KeyMap[KeyCode::Down] = GameButton::Down;
 
-   inputConfig->KeyMap[KeyCode::Return] = GameButton::Start;
-   inputConfig->KeyMap[KeyCode::Tab] = GameButton::Select;
+   inputDefs->KeyMap[KeyCode::Return] = GameButton::Start;
+   inputDefs->KeyMap[KeyCode::Tab] = GameButton::Select;
 
-   inputConfig->KeyMap[KeyCode::A] = GameButton::A;
-   inputConfig->KeyMap[KeyCode::Return] = GameButton::A;
-   inputConfig->KeyMap[KeyCode::Space] = GameButton::A;
-   inputConfig->KeyMap[KeyCode::B] = GameButton::B;
-   inputConfig->KeyMap[KeyCode::X] = GameButton::X;
-   inputConfig->KeyMap[KeyCode::Y] = GameButton::Y;
+   inputDefs->KeyMap[KeyCode::A] = GameButton::A;
+   inputDefs->KeyMap[KeyCode::Return] = GameButton::A;
+   inputDefs->KeyMap[KeyCode::Space] = GameButton::A;
+   inputDefs->KeyMap[KeyCode::B] = GameButton::B;
+   inputDefs->KeyMap[KeyCode::X] = GameButton::X;
+   inputDefs->KeyMap[KeyCode::Y] = GameButton::Y;
 
-   inputConfig->KeyMap[KeyCode::NumPad1] = GameButton::L1;
-   inputConfig->KeyMap[KeyCode::NumPad2] = GameButton::L2;
-   inputConfig->KeyMap[KeyCode::NumPad3] = GameButton::R1;
-   inputConfig->KeyMap[KeyCode::NumPad4] = GameButton::R2;
+   inputDefs->KeyMap[KeyCode::NumPad1] = GameButton::L1;
+   inputDefs->KeyMap[KeyCode::NumPad2] = GameButton::L2;
+   inputDefs->KeyMap[KeyCode::NumPad3] = GameButton::R1;
+   inputDefs->KeyMap[KeyCode::NumPad4] = GameButton::R2;
 
-   inputConfig->KeyMap[KeyCode::F12] = GameButton::Diagnostics;
+   inputDefs->KeyMap[KeyCode::F12] = GameButton::Diagnostics;
 
    // key names
-   inputConfig->KeyNames[KeyCode::Left] = "Left Arrow";
-   inputConfig->KeyNames[KeyCode::Up] = "Up Arrow";
-   inputConfig->KeyNames[KeyCode::Right] = "Right Arrow";
-   inputConfig->KeyNames[KeyCode::Down] = "Down Arrow";
-   inputConfig->KeyNames[KeyCode::Return] = "Enter";
-   inputConfig->KeyNames[KeyCode::Space] = "Space Bar";
-   inputConfig->KeyNames[KeyCode::Tab] = "Tab";
-   inputConfig->KeyNames[KeyCode::A] = "A";
-   inputConfig->KeyNames[KeyCode::B] = "B";
-   inputConfig->KeyNames[KeyCode::X] = "X";
-   inputConfig->KeyNames[KeyCode::Y] = "Y";
-   inputConfig->KeyNames[KeyCode::NumPad1] = "1";
-   inputConfig->KeyNames[KeyCode::NumPad2] = "2";
-   inputConfig->KeyNames[KeyCode::NumPad3] = "3";
-   inputConfig->KeyNames[KeyCode::NumPad4] = "4";
-   inputConfig->KeyNames[KeyCode::F12] = "F12";
+   inputDefs->KeyNames[KeyCode::Left] = "Left Arrow";
+   inputDefs->KeyNames[KeyCode::Up] = "Up Arrow";
+   inputDefs->KeyNames[KeyCode::Right] = "Right Arrow";
+   inputDefs->KeyNames[KeyCode::Down] = "Down Arrow";
+   inputDefs->KeyNames[KeyCode::Return] = "Enter";
+   inputDefs->KeyNames[KeyCode::Space] = "Space Bar";
+   inputDefs->KeyNames[KeyCode::Tab] = "Tab";
+   inputDefs->KeyNames[KeyCode::A] = "A";
+   inputDefs->KeyNames[KeyCode::B] = "B";
+   inputDefs->KeyNames[KeyCode::X] = "X";
+   inputDefs->KeyNames[KeyCode::Y] = "Y";
+   inputDefs->KeyNames[KeyCode::NumPad1] = "1";
+   inputDefs->KeyNames[KeyCode::NumPad2] = "2";
+   inputDefs->KeyNames[KeyCode::NumPad3] = "3";
+   inputDefs->KeyNames[KeyCode::NumPad4] = "4";
+   inputDefs->KeyNames[KeyCode::F12] = "F12";
 
    // button names
-   inputConfig->ButtonNames[GameButton::Left] = "Left";
-   inputConfig->ButtonNames[GameButton::Up] = "Up";
-   inputConfig->ButtonNames[GameButton::Right] = "Right";
-   inputConfig->ButtonNames[GameButton::Down] = "Down";
-   inputConfig->ButtonNames[GameButton::Start] = "Start";
-   inputConfig->ButtonNames[GameButton::Select] = "Select";
-   inputConfig->ButtonNames[GameButton::A] = "A";
-   inputConfig->ButtonNames[GameButton::B] = "B";
-   inputConfig->ButtonNames[GameButton::X] = "X";
-   inputConfig->ButtonNames[GameButton::Y] = "Y";
-   inputConfig->ButtonNames[GameButton::L1] = "L1";
-   inputConfig->ButtonNames[GameButton::L2] = "L2";
-   inputConfig->ButtonNames[GameButton::R1] = "R1";
-   inputConfig->ButtonNames[GameButton::R2] = "R2";
-   inputConfig->ButtonNames[GameButton::Diagnostics] = "Toggle Diagnostics";
+   inputDefs->ButtonNames[GameButton::Left] = "Left";
+   inputDefs->ButtonNames[GameButton::Up] = "Up";
+   inputDefs->ButtonNames[GameButton::Right] = "Right";
+   inputDefs->ButtonNames[GameButton::Down] = "Down";
+   inputDefs->ButtonNames[GameButton::Start] = "Start";
+   inputDefs->ButtonNames[GameButton::Select] = "Select";
+   inputDefs->ButtonNames[GameButton::A] = "A";
+   inputDefs->ButtonNames[GameButton::B] = "B";
+   inputDefs->ButtonNames[GameButton::X] = "X";
+   inputDefs->ButtonNames[GameButton::Y] = "Y";
+   inputDefs->ButtonNames[GameButton::L1] = "L1";
+   inputDefs->ButtonNames[GameButton::L2] = "L2";
+   inputDefs->ButtonNames[GameButton::R1] = "R1";
+   inputDefs->ButtonNames[GameButton::R2] = "R2";
+   inputDefs->ButtonNames[GameButton::Diagnostics] = "Toggle Diagnostics";
 
-   return inputConfig;
+   return inputDefs;
 }
 
 shared_ptr<PlayerConfig> BuildPlayerConfig()
@@ -294,7 +294,7 @@ shared_ptr<GameConfig> BuildGameConfig()
    config->FramesPerSecond = 60;
 
    config->RenderDefs = BuildConsoleRenderDefs();
-   config->InputConfig = BuildKeyboardInputConfig();
+   config->InputDefs = BuildKeyboardInputDefs();
    config->PlayerConfig = BuildPlayerConfig();
    config->ArenaDefs = BuildArenaDefs();
 

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -4,7 +4,7 @@
 #include <fcntl.h>
 
 #include "GameConfig.h"
-#include "ConsoleRenderConfig.h"
+#include "ConsoleRenderDefs.h"
 #include "KeyboardInputConfig.h"
 #include "PlayerConfig.h"
 #include "ArenaDefs.h"
@@ -38,7 +38,7 @@ using namespace ConsoleGame;
 // TODO: I suppose these configs should be loaded from files at some point,
 // but at the very least they should all have default values, and those could
 // probably be set in some initializer instead of in here.
-shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig();
+shared_ptr<ConsoleRenderDefs> BuildConsoleRenderDefs();
 shared_ptr<KeyboardInputConfig> BuildKeyboardInputConfig();
 shared_ptr<PlayerConfig> BuildPlayerConfig();
 shared_ptr<ArenaDefs> BuildArenaDefs();
@@ -79,7 +79,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 
    // configs
    auto config = BuildGameConfig();
-   auto consoleRenderConfig = static_pointer_cast<ConsoleRenderConfig>( config->RenderConfig );
+   auto consoleRenderDefs = static_pointer_cast<ConsoleRenderDefs>( config->RenderDefs );
    auto keyboardInputConfig = static_pointer_cast<KeyboardInputConfig>( config->InputConfig );
 
    // wrappers
@@ -105,10 +105,10 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    inputHandler->AddInputHandlerForGameState( GameState::Playing, playingStateInputHandler );
 
    // rendering objects
-   auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderConfig ) );
-   auto startupStateConsoleRenderer = shared_ptr<StartupStateConsoleRenderer>( new StartupStateConsoleRenderer( consoleBuffer, consoleRenderConfig, keyboardInputConfig ) );
-   auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderConfig, game ) );
-   auto renderer = shared_ptr<GameRenderer>( new GameRenderer( consoleRenderConfig, consoleBuffer, game, diagnosticsRenderer, eventAggregator ) );
+   auto diagnosticsRenderer = shared_ptr<DiagnosticsConsoleRenderer>( new DiagnosticsConsoleRenderer( consoleBuffer, clock, consoleRenderDefs ) );
+   auto startupStateConsoleRenderer = shared_ptr<StartupStateConsoleRenderer>( new StartupStateConsoleRenderer( consoleBuffer, consoleRenderDefs, keyboardInputConfig ) );
+   auto playingStateConsoleRenderer = shared_ptr<PlayingStateConsoleRenderer>( new PlayingStateConsoleRenderer( consoleBuffer, consoleRenderDefs, game ) );
+   auto renderer = shared_ptr<GameRenderer>( new GameRenderer( consoleRenderDefs, consoleBuffer, game, diagnosticsRenderer, eventAggregator ) );
    renderer->AddRendererForGameState( GameState::Startup, startupStateConsoleRenderer );
    renderer->AddRendererForGameState( GameState::Playing, playingStateConsoleRenderer );
 
@@ -118,75 +118,75 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    runner->Run();
 }
 
-shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig()
+shared_ptr<ConsoleRenderDefs> BuildConsoleRenderDefs()
 {
-   auto renderConfig = make_shared<ConsoleRenderConfig>();
+   auto renderDefs = make_shared<ConsoleRenderDefs>();
 
-   renderConfig->ConsoleWidth = 120;
-   renderConfig->ConsoleHeight = 30;
+   renderDefs->ConsoleWidth = 120;
+   renderDefs->ConsoleHeight = 30;
 
-   renderConfig->ArenaCharWidth = 114;
-   renderConfig->ArenaCharHeight = 24;
+   renderDefs->ArenaCharWidth = 114;
+   renderDefs->ArenaCharHeight = 24;
 
-   renderConfig->ArenaFenceX = 2;
-   renderConfig->ArenaFenceY = 3;
+   renderDefs->ArenaFenceX = 2;
+   renderDefs->ArenaFenceY = 3;
 
-   renderConfig->DefaultForegroundColor = ConsoleColor::Grey;
-   renderConfig->DefaultBackgroundColor = ConsoleColor::Black;
+   renderDefs->DefaultForegroundColor = ConsoleColor::Grey;
+   renderDefs->DefaultBackgroundColor = ConsoleColor::Black;
 
-   renderConfig->PlayerStaticSprite.Width = 1;
-   renderConfig->PlayerStaticSprite.Height = 1;
-   renderConfig->PlayerStaticSprite.Pixels.push_back( { '*', ConsoleColor::White } );
+   renderDefs->PlayerStaticSprite.Width = 1;
+   renderDefs->PlayerStaticSprite.Height = 1;
+   renderDefs->PlayerStaticSprite.Pixels.push_back( { '*', ConsoleColor::White } );
 
-   renderConfig->PlayerMovingSpriteMap[Direction::Left].Width = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::Left].Height = 1;
-   renderConfig->PlayerMovingSpriteMap[Direction::Left].Pixels.push_back( { '+', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::Left].Pixels.push_back( { '-', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::Left].Width = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::Left].Height = 1;
+   renderDefs->PlayerMovingSpriteMap[Direction::Left].Pixels.push_back( { '+', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::Left].Pixels.push_back( { '-', ConsoleColor::White } );
 
-   renderConfig->PlayerMovingSpriteMap[Direction::UpLeft].Width = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::UpLeft].Height = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::UpLeft].Pixels.push_back( { '+', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::UpLeft].Pixels.push_back( { ' ', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::UpLeft].Pixels.push_back( { ' ', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::UpLeft].Pixels.push_back( { '\\', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::UpLeft].Width = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::UpLeft].Height = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::UpLeft].Pixels.push_back( { '+', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::UpLeft].Pixels.push_back( { ' ', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::UpLeft].Pixels.push_back( { ' ', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::UpLeft].Pixels.push_back( { '\\', ConsoleColor::White } );
 
-   renderConfig->PlayerMovingSpriteMap[Direction::Up].Width = 1;
-   renderConfig->PlayerMovingSpriteMap[Direction::Up].Height = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::Up].Pixels.push_back( { '+', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::Up].Pixels.push_back( { '|', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::Up].Width = 1;
+   renderDefs->PlayerMovingSpriteMap[Direction::Up].Height = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::Up].Pixels.push_back( { '+', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::Up].Pixels.push_back( { '|', ConsoleColor::White } );
 
-   renderConfig->PlayerMovingSpriteMap[Direction::UpRight].Width = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::UpRight].Height = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::UpRight].Pixels.push_back( { ' ', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::UpRight].Pixels.push_back( { '+', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::UpRight].Pixels.push_back( { '/', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::UpRight].Pixels.push_back( { ' ', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::UpRight].Width = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::UpRight].Height = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::UpRight].Pixels.push_back( { ' ', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::UpRight].Pixels.push_back( { '+', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::UpRight].Pixels.push_back( { '/', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::UpRight].Pixels.push_back( { ' ', ConsoleColor::White } );
 
-   renderConfig->PlayerMovingSpriteMap[Direction::Right].Width = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::Right].Height = 1;
-   renderConfig->PlayerMovingSpriteMap[Direction::Right].Pixels.push_back( { '-', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::Right].Pixels.push_back( { '+', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::Right].Width = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::Right].Height = 1;
+   renderDefs->PlayerMovingSpriteMap[Direction::Right].Pixels.push_back( { '-', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::Right].Pixels.push_back( { '+', ConsoleColor::White } );
 
-   renderConfig->PlayerMovingSpriteMap[Direction::DownRight].Width = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::DownRight].Height = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::DownRight].Pixels.push_back( { '\\', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::DownRight].Pixels.push_back( { ' ', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::DownRight].Pixels.push_back( { ' ', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::DownRight].Pixels.push_back( { '+', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::DownRight].Width = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::DownRight].Height = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::DownRight].Pixels.push_back( { '\\', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::DownRight].Pixels.push_back( { ' ', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::DownRight].Pixels.push_back( { ' ', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::DownRight].Pixels.push_back( { '+', ConsoleColor::White } );
 
-   renderConfig->PlayerMovingSpriteMap[Direction::Down].Width = 1;
-   renderConfig->PlayerMovingSpriteMap[Direction::Down].Height = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::Down].Pixels.push_back( { '|', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::Down].Pixels.push_back( { '+', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::Down].Width = 1;
+   renderDefs->PlayerMovingSpriteMap[Direction::Down].Height = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::Down].Pixels.push_back( { '|', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::Down].Pixels.push_back( { '+', ConsoleColor::White } );
 
-   renderConfig->PlayerMovingSpriteMap[Direction::DownLeft].Width = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::DownLeft].Height = 2;
-   renderConfig->PlayerMovingSpriteMap[Direction::DownLeft].Pixels.push_back( { ' ', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::DownLeft].Pixels.push_back( { '/', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::DownLeft].Pixels.push_back( { '+', ConsoleColor::White } );
-   renderConfig->PlayerMovingSpriteMap[Direction::DownLeft].Pixels.push_back( { ' ', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::DownLeft].Width = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::DownLeft].Height = 2;
+   renderDefs->PlayerMovingSpriteMap[Direction::DownLeft].Pixels.push_back( { ' ', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::DownLeft].Pixels.push_back( { '/', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::DownLeft].Pixels.push_back( { '+', ConsoleColor::White } );
+   renderDefs->PlayerMovingSpriteMap[Direction::DownLeft].Pixels.push_back( { ' ', ConsoleColor::White } );
 
-   return renderConfig;
+   return renderDefs;
 }
 
 shared_ptr<KeyboardInputConfig> BuildKeyboardInputConfig()
@@ -293,7 +293,7 @@ shared_ptr<GameConfig> BuildGameConfig()
 
    config->FramesPerSecond = 60;
 
-   config->RenderConfig = BuildConsoleRenderConfig();
+   config->RenderDefs = BuildConsoleRenderDefs();
    config->InputConfig = BuildKeyboardInputConfig();
    config->PlayerConfig = BuildPlayerConfig();
    config->ArenaDefs = BuildArenaDefs();

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -3,7 +3,7 @@
 #include <io.h>
 #include <fcntl.h>
 
-#include "GameConfig.h"
+#include "GameDefs.h"
 #include "ConsoleRenderDefs.h"
 #include "KeyboardInputDefs.h"
 #include "PlayerDefs.h"
@@ -42,7 +42,7 @@ shared_ptr<ConsoleRenderDefs> BuildConsoleRenderDefs();
 shared_ptr<KeyboardInputDefs> BuildKeyboardInputDefs();
 shared_ptr<PlayerDefs> BuildPlayerDefs();
 shared_ptr<ArenaDefs> BuildArenaDefs();
-shared_ptr<GameConfig> BuildGameConfig();
+shared_ptr<GameDefs> BuildGameDefs();
 void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer );
 
 INT WINAPI WinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ PSTR lpCmdLine, _In_ INT nCmdShow )
@@ -78,9 +78,9 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    consoleBuffer->Flip();
 
    // configs
-   auto config = BuildGameConfig();
-   auto consoleRenderDefs = static_pointer_cast<ConsoleRenderDefs>( config->RenderDefs );
-   auto keyboardInputDefs = static_pointer_cast<KeyboardInputDefs>( config->InputDefs );
+   auto gameDefs = BuildGameDefs();
+   auto consoleRenderDefs = static_pointer_cast<ConsoleRenderDefs>( gameDefs->RenderDefs );
+   auto keyboardInputDefs = static_pointer_cast<KeyboardInputDefs>( gameDefs->InputDefs );
 
    // wrappers
    auto highResolutionClock = shared_ptr<HighResolutionClockWrapper>( new HighResolutionClockWrapper() );
@@ -90,12 +90,12 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
 
    // auxiliary objects
    auto eventAggregator = shared_ptr<GameEventAggregator>( new GameEventAggregator() );
-   auto clock = shared_ptr<GameClock>( new GameClock( highResolutionClock, sleeper, config->FramesPerSecond ) );
+   auto clock = shared_ptr<GameClock>( new GameClock( highResolutionClock, sleeper, gameDefs->FramesPerSecond ) );
    auto keyboardInputReader = shared_ptr<KeyboardInputReader>( new KeyboardInputReader( keyboardInputDefs, keyboard ) );
 
    // game data objects
-   auto playerFactory = shared_ptr<IPlayerFactory>( new PlayerFactory( config ) );
-   auto game = shared_ptr<Game>( new Game( config, eventAggregator, playerFactory ) );
+   auto playerFactory = shared_ptr<IPlayerFactory>( new PlayerFactory( gameDefs ) );
+   auto game = shared_ptr<Game>( new Game( gameDefs, eventAggregator, playerFactory ) );
 
    // input objects
    auto startupStateInputHandler = shared_ptr<StartupStateInputHandler>( new StartupStateInputHandler( keyboardInputReader, game ) );
@@ -287,16 +287,16 @@ shared_ptr<ArenaDefs> BuildArenaDefs()
    return arenaDefs;
 }
 
-shared_ptr<GameConfig> BuildGameConfig()
+shared_ptr<GameDefs> BuildGameDefs()
 {
-   auto config = make_shared<GameConfig>();
+   auto gameDefs = make_shared<GameDefs>();
 
-   config->FramesPerSecond = 60;
+   gameDefs->FramesPerSecond = 60;
 
-   config->RenderDefs = BuildConsoleRenderDefs();
-   config->InputDefs = BuildKeyboardInputDefs();
-   config->PlayerDefs = BuildPlayerDefs();
-   config->ArenaDefs = BuildArenaDefs();
+   gameDefs->RenderDefs = BuildConsoleRenderDefs();
+   gameDefs->InputDefs = BuildKeyboardInputDefs();
+   gameDefs->PlayerDefs = BuildPlayerDefs();
+   gameDefs->ArenaDefs = BuildArenaDefs();
 
-   return config;
+   return gameDefs;
 }

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -6,7 +6,7 @@
 #include "GameConfig.h"
 #include "ConsoleRenderDefs.h"
 #include "KeyboardInputDefs.h"
-#include "PlayerConfig.h"
+#include "PlayerDefs.h"
 #include "ArenaDefs.h"
 #include "KeyCode.h"
 #include "GameButton.h"
@@ -40,7 +40,7 @@ using namespace ConsoleGame;
 // probably be set in some initializer instead of in here.
 shared_ptr<ConsoleRenderDefs> BuildConsoleRenderDefs();
 shared_ptr<KeyboardInputDefs> BuildKeyboardInputDefs();
-shared_ptr<PlayerConfig> BuildPlayerConfig();
+shared_ptr<PlayerDefs> BuildPlayerDefs();
 shared_ptr<ArenaDefs> BuildArenaDefs();
 shared_ptr<GameConfig> BuildGameConfig();
 void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer );
@@ -254,24 +254,24 @@ shared_ptr<KeyboardInputDefs> BuildKeyboardInputDefs()
    return inputDefs;
 }
 
-shared_ptr<PlayerConfig> BuildPlayerConfig()
+shared_ptr<PlayerDefs> BuildPlayerDefs()
 {
-   auto playerConfig = make_shared<PlayerConfig>();
+   auto playerDefs = make_shared<PlayerDefs>();
 
-   playerConfig->StartVelocityX = 0.;
-   playerConfig->StartVelocityY = 0.;
+   playerDefs->StartVelocityX = 0.;
+   playerDefs->StartVelocityY = 0.;
 
    // this means at max velocity, it should take
    // 3 seconds to cross the arena horizontally
-   playerConfig->MaxVelocity = 1444.;
+   playerDefs->MaxVelocity = 1444.;
 
    // this means it should take a third of a second
    // to go from 0 to max velocity
-   playerConfig->AccelerationPerSecond = 4332.;
+   playerDefs->AccelerationPerSecond = 4332.;
 
-   playerConfig->StartDirection = Direction::Right;
+   playerDefs->StartDirection = Direction::Right;
 
-   return playerConfig;
+   return playerDefs;
 }
 
 shared_ptr<ArenaDefs> BuildArenaDefs()
@@ -295,7 +295,7 @@ shared_ptr<GameConfig> BuildGameConfig()
 
    config->RenderDefs = BuildConsoleRenderDefs();
    config->InputDefs = BuildKeyboardInputDefs();
-   config->PlayerConfig = BuildPlayerConfig();
+   config->PlayerDefs = BuildPlayerDefs();
    config->ArenaDefs = BuildArenaDefs();
 
    return config;

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -7,7 +7,7 @@
 #include "ConsoleRenderConfig.h"
 #include "KeyboardInputConfig.h"
 #include "PlayerConfig.h"
-#include "ArenaConfig.h"
+#include "ArenaDefs.h"
 #include "KeyCode.h"
 #include "GameButton.h"
 #include "HighResolutionClockWrapper.h"
@@ -41,7 +41,7 @@ using namespace ConsoleGame;
 shared_ptr<ConsoleRenderConfig> BuildConsoleRenderConfig();
 shared_ptr<KeyboardInputConfig> BuildKeyboardInputConfig();
 shared_ptr<PlayerConfig> BuildPlayerConfig();
-shared_ptr<ArenaConfig> BuildArenaConfig();
+shared_ptr<ArenaDefs> BuildArenaDefs();
 shared_ptr<GameConfig> BuildGameConfig();
 void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer );
 
@@ -274,17 +274,17 @@ shared_ptr<PlayerConfig> BuildPlayerConfig()
    return playerConfig;
 }
 
-shared_ptr<ArenaConfig> BuildArenaConfig()
+shared_ptr<ArenaDefs> BuildArenaDefs()
 {
-   auto arenaConfig = make_shared<ArenaConfig>();
+   auto arenaDefs = make_shared<ArenaDefs>();
 
-   arenaConfig->Width = 4332.;
-   arenaConfig->Height = 1872.;
+   arenaDefs->Width = 4332.;
+   arenaDefs->Height = 1872.;
 
-   arenaConfig->PlayerStartX = arenaConfig->Width / 2.;
-   arenaConfig->PlayerStartY = arenaConfig->Height / 2.;
+   arenaDefs->PlayerStartX = arenaDefs->Width / 2.;
+   arenaDefs->PlayerStartY = arenaDefs->Height / 2.;
 
-   return arenaConfig;
+   return arenaDefs;
 }
 
 shared_ptr<GameConfig> BuildGameConfig()
@@ -296,7 +296,7 @@ shared_ptr<GameConfig> BuildGameConfig()
    config->RenderConfig = BuildConsoleRenderConfig();
    config->InputConfig = BuildKeyboardInputConfig();
    config->PlayerConfig = BuildPlayerConfig();
-   config->ArenaConfig = BuildArenaConfig();
+   config->ArenaDefs = BuildArenaDefs();
 
    return config;
 }

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -8,8 +8,6 @@
 #include "KeyboardInputDefs.h"
 #include "PlayerDefs.h"
 #include "ArenaDefs.h"
-#include "KeyCode.h"
-#include "GameButton.h"
 #include "HighResolutionClockWrapper.h"
 #include "SleeperWrapper.h"
 #include "KeyboardWrapper.h"
@@ -28,9 +26,6 @@
 #include "PlayingStateConsoleRenderer.h"
 #include "GameRenderer.h"
 #include "GameRunner.h"
-#include "GameState.h"
-#include "ConsoleColor.h"
-#include "Direction.h"
 
 using namespace std;
 using namespace ConsoleGame;

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -35,7 +35,7 @@
 using namespace std;
 using namespace ConsoleGame;
 
-// TODO: I suppose these configs should be loaded from files at some point,
+// TODO: I suppose these defs should be loaded from files at some point,
 // but at the very least they should all have default values, and those could
 // probably be set in some initializer instead of in here.
 shared_ptr<ConsoleRenderDefs> BuildConsoleRenderDefs();
@@ -77,7 +77,7 @@ void LoadAndRun( const shared_ptr<IConsoleBuffer> consoleBuffer )
    consoleBuffer->Draw( 2, 1, "Loading all the things..." );
    consoleBuffer->Flip();
 
-   // configs
+   // defs
    auto gameDefs = BuildGameDefs();
    auto consoleRenderDefs = static_pointer_cast<ConsoleRenderDefs>( gameDefs->RenderDefs );
    auto keyboardInputDefs = static_pointer_cast<KeyboardInputDefs>( gameDefs->InputDefs );

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -217,7 +217,7 @@
     <ClInclude Include="PushPlayerCommandArgs.h" />
     <ClInclude Include="ConsolePixel.h" />
     <ClInclude Include="Player.h" />
-    <ClInclude Include="PlayerConfig.h" />
+    <ClInclude Include="PlayerDefs.h" />
     <ClInclude Include="PlayerFactory.h" />
     <ClInclude Include="PlayingStateConsoleRenderer.h" />
     <ClInclude Include="PlayingStateInputHandler.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -78,11 +78,11 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -171,7 +171,7 @@
     <ClCompile Include="ThreadWrapper.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="ArenaConfig.h" />
+    <ClInclude Include="ArenaDefs.h" />
     <ClInclude Include="ConsoleColor.h" />
     <ClInclude Include="ConsoleBuffer.h" />
     <ClInclude Include="ConsoleSprite.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -182,7 +182,7 @@
     <ClInclude Include="GameClock.h" />
     <ClInclude Include="GameCommand.h" />
     <ClInclude Include="GameCommandArgs.h" />
-    <ClInclude Include="GameConfig.h" />
+    <ClInclude Include="GameDefs.h" />
     <ClInclude Include="GameRenderer.h" />
     <ClInclude Include="GameEvent.h" />
     <ClInclude Include="GameEventAggregator.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -191,7 +191,7 @@
     <ClInclude Include="GameState.h" />
     <ClInclude Include="IGame.h" />
     <ClInclude Include="IGameInfoProvider.h" />
-    <ClInclude Include="IGameInputConfig.h" />
+    <ClInclude Include="IGameInputDefs.h" />
     <ClInclude Include="IGameRenderDefs.h" />
     <ClInclude Include="IPlayer.h" />
     <ClInclude Include="IPlayerFactory.h" />
@@ -208,7 +208,7 @@
     <ClInclude Include="IGameRenderer.h" />
     <ClInclude Include="IGameRunner.h" />
     <ClInclude Include="GameInputHandler.h" />
-    <ClInclude Include="KeyboardInputConfig.h" />
+    <ClInclude Include="KeyboardInputDefs.h" />
     <ClInclude Include="IHighResolutionClock.h" />
     <ClInclude Include="IKeyboard.h" />
     <ClInclude Include="ISleeper.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj
+++ b/ConsoleGame/ConsoleGame.vcxproj
@@ -186,13 +186,13 @@
     <ClInclude Include="GameRenderer.h" />
     <ClInclude Include="GameEvent.h" />
     <ClInclude Include="GameEventAggregator.h" />
-    <ClInclude Include="ConsoleRenderConfig.h" />
+    <ClInclude Include="ConsoleRenderDefs.h" />
     <ClInclude Include="GameRunner.h" />
     <ClInclude Include="GameState.h" />
     <ClInclude Include="IGame.h" />
     <ClInclude Include="IGameInfoProvider.h" />
     <ClInclude Include="IGameInputConfig.h" />
-    <ClInclude Include="IGameRenderConfig.h" />
+    <ClInclude Include="IGameRenderDefs.h" />
     <ClInclude Include="IPlayer.h" />
     <ClInclude Include="IPlayerFactory.h" />
     <ClInclude Include="IScreenBuffer.h" />

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -176,7 +176,7 @@
     <ClInclude Include="GameConfig.h">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
-    <ClInclude Include="ConsoleRenderConfig.h">
+    <ClInclude Include="ConsoleRenderDefs.h">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
     <ClInclude Include="KeyboardInputConfig.h">
@@ -230,7 +230,7 @@
     <ClInclude Include="ConsoleSprite.h">
       <Filter>Header Files\DataTypes</Filter>
     </ClInclude>
-    <ClInclude Include="IGameRenderConfig.h">
+    <ClInclude Include="IGameRenderDefs.h">
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
     <ClInclude Include="IGameInputConfig.h">

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -179,7 +179,7 @@
     <ClInclude Include="ConsoleRenderDefs.h">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
-    <ClInclude Include="KeyboardInputConfig.h">
+    <ClInclude Include="KeyboardInputDefs.h">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
     <ClInclude Include="DiagnosticsConsoleRenderer.h">
@@ -233,7 +233,7 @@
     <ClInclude Include="IGameRenderDefs.h">
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
-    <ClInclude Include="IGameInputConfig.h">
+    <ClInclude Include="IGameInputDefs.h">
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
     <ClInclude Include="IScreenBuffer.h">

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -257,7 +257,7 @@
     <ClInclude Include="IGame.h">
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
-    <ClInclude Include="ArenaConfig.h">
+    <ClInclude Include="ArenaDefs.h">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
     <ClInclude Include="IGameInfoProvider.h">

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -173,7 +173,7 @@
     <ClInclude Include="StartupStateConsoleRenderer.h">
       <Filter>Header Files\Render</Filter>
     </ClInclude>
-    <ClInclude Include="GameConfig.h">
+    <ClInclude Include="GameDefs.h">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
     <ClInclude Include="ConsoleRenderDefs.h">

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -251,7 +251,7 @@
     <ClInclude Include="PlayerFactory.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="PlayerConfig.h">
+    <ClInclude Include="PlayerDefs.h">
       <Filter>Header Files\Config</Filter>
     </ClInclude>
     <ClInclude Include="IGame.h">

--- a/ConsoleGame/ConsoleGame.vcxproj.filters
+++ b/ConsoleGame/ConsoleGame.vcxproj.filters
@@ -31,9 +31,6 @@
     <Filter Include="Source Files\Render">
       <UniqueIdentifier>{72e4b4f7-3f00-40f2-bb2f-68c19aef96d4}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Header Files\Config">
-      <UniqueIdentifier>{3d844f74-be55-4dd0-b069-ece15e0fba1b}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Header Files\Wrappers">
       <UniqueIdentifier>{82f7e089-e48f-47eb-a1b9-e2f92e1392e4}</UniqueIdentifier>
     </Filter>
@@ -42,6 +39,9 @@
     </Filter>
     <Filter Include="Header Files\CommandArgs">
       <UniqueIdentifier>{c79bef2d-4ae2-4f2d-979d-26aea4e9ea68}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\GameDefs">
+      <UniqueIdentifier>{3d844f74-be55-4dd0-b069-ece15e0fba1b}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -174,13 +174,13 @@
       <Filter>Header Files\Render</Filter>
     </ClInclude>
     <ClInclude Include="GameDefs.h">
-      <Filter>Header Files\Config</Filter>
+      <Filter>Header Files\GameDefs</Filter>
     </ClInclude>
     <ClInclude Include="ConsoleRenderDefs.h">
-      <Filter>Header Files\Config</Filter>
+      <Filter>Header Files\GameDefs</Filter>
     </ClInclude>
     <ClInclude Include="KeyboardInputDefs.h">
-      <Filter>Header Files\Config</Filter>
+      <Filter>Header Files\GameDefs</Filter>
     </ClInclude>
     <ClInclude Include="DiagnosticsConsoleRenderer.h">
       <Filter>Header Files\Render</Filter>
@@ -252,13 +252,13 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="PlayerDefs.h">
-      <Filter>Header Files\Config</Filter>
+      <Filter>Header Files\GameDefs</Filter>
     </ClInclude>
     <ClInclude Include="IGame.h">
       <Filter>Header Files\Interfaces</Filter>
     </ClInclude>
     <ClInclude Include="ArenaDefs.h">
-      <Filter>Header Files\Config</Filter>
+      <Filter>Header Files\GameDefs</Filter>
     </ClInclude>
     <ClInclude Include="IGameInfoProvider.h">
       <Filter>Header Files\Interfaces</Filter>

--- a/ConsoleGame/ConsolePixel.h
+++ b/ConsoleGame/ConsolePixel.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "ConsoleColor.h"
+
 namespace ConsoleGame
 {
-   enum class ConsoleColor;
-
    struct ConsolePixel
    {
       char Value = '\0';

--- a/ConsoleGame/ConsoleRenderDefs.h
+++ b/ConsoleGame/ConsoleRenderDefs.h
@@ -2,7 +2,7 @@
 
 #include <map>
 
-#include "IGameRenderConfig.h"
+#include "IGameRenderDefs.h"
 #include "ConsoleSprite.h"
 
 namespace ConsoleGame
@@ -10,7 +10,7 @@ namespace ConsoleGame
    enum class ConsoleColor;
    enum class Direction;
 
-   class ConsoleRenderConfig : public IGameRenderConfig
+   class ConsoleRenderDefs : public IGameRenderDefs
    {
    public:
       short ConsoleWidth = 0;

--- a/ConsoleGame/ConsoleRenderDefs.h
+++ b/ConsoleGame/ConsoleRenderDefs.h
@@ -4,12 +4,10 @@
 
 #include "IGameRenderDefs.h"
 #include "ConsoleSprite.h"
+#include "Direction.h"
 
 namespace ConsoleGame
 {
-   enum class ConsoleColor;
-   enum class Direction;
-
    class ConsoleRenderDefs : public IGameRenderDefs
    {
    public:

--- a/ConsoleGame/DiagnosticsConsoleRenderer.cpp
+++ b/ConsoleGame/DiagnosticsConsoleRenderer.cpp
@@ -4,7 +4,6 @@
 #include "IConsoleBuffer.h"
 #include "IGameClock.h"
 #include "ConsoleRenderDefs.h"
-#include "ConsoleColor.h"
 
 #define DIAGNOSTICS_WIDTH 30
 

--- a/ConsoleGame/DiagnosticsConsoleRenderer.cpp
+++ b/ConsoleGame/DiagnosticsConsoleRenderer.cpp
@@ -3,7 +3,7 @@
 #include "DiagnosticsConsoleRenderer.h"
 #include "IConsoleBuffer.h"
 #include "IGameClock.h"
-#include "ConsoleRenderConfig.h"
+#include "ConsoleRenderDefs.h"
 #include "ConsoleColor.h"
 
 #define DIAGNOSTICS_WIDTH 30
@@ -13,16 +13,16 @@ using namespace ConsoleGame;
 
 DiagnosticsConsoleRenderer::DiagnosticsConsoleRenderer( const shared_ptr<IConsoleBuffer> consoleBuffer,
                                                         const shared_ptr<IGameClock> clock,
-                                                        const shared_ptr<ConsoleRenderConfig> renderConfig ) :
+                                                        const shared_ptr<ConsoleRenderDefs> renderDefs ) :
    _consoleBuffer( consoleBuffer ),
    _clock( clock ),
-   _renderConfig( renderConfig )
+   _renderDefs( renderDefs )
 {
 }
 
 void DiagnosticsConsoleRenderer::Render()
 {
-   auto left = _renderConfig->ConsoleWidth - DIAGNOSTICS_WIDTH;
+   auto left = _renderDefs->ConsoleWidth - DIAGNOSTICS_WIDTH;
 
    auto framesPerSecondString = format( " Frames per second: {0} ", _clock->GetFramesPerSecond() );
    auto totalFramesString = format( " Total frames:      {0} ", _clock->GetTotalFrameCount() );

--- a/ConsoleGame/DiagnosticsConsoleRenderer.h
+++ b/ConsoleGame/DiagnosticsConsoleRenderer.h
@@ -8,20 +8,20 @@ namespace ConsoleGame
 {
    class IConsoleBuffer;
    class IGameClock;
-   class ConsoleRenderConfig;
+   class ConsoleRenderDefs;
 
    class DiagnosticsConsoleRenderer : public IGameRenderer
    {
    public:
       DiagnosticsConsoleRenderer( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
                                   const std::shared_ptr<IGameClock> clock,
-                                  const std::shared_ptr<ConsoleRenderConfig> renderConfig );
+                                  const std::shared_ptr<ConsoleRenderDefs> renderDefs );
 
       void Render() override;
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
       const std::shared_ptr<IGameClock> _clock;
-      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
+      const std::shared_ptr<ConsoleRenderDefs> _renderDefs;
    };
 }

--- a/ConsoleGame/Game.cpp
+++ b/ConsoleGame/Game.cpp
@@ -1,6 +1,5 @@
 #include "Game.h"
 #include "GameConfig.h"
-#include "PlayerConfig.h"
 #include "ArenaDefs.h"
 #include "IGameEventAggregator.h"
 #include "IPlayerFactory.h"

--- a/ConsoleGame/Game.cpp
+++ b/ConsoleGame/Game.cpp
@@ -4,10 +4,6 @@
 #include "IGameEventAggregator.h"
 #include "IPlayerFactory.h"
 #include "IPlayer.h"
-#include "GameState.h"
-#include "GameCommand.h"
-#include "GameEvent.h"
-#include "Direction.h"
 #include "PushPlayerCommandArgs.h"
 
 using namespace std;

--- a/ConsoleGame/Game.cpp
+++ b/ConsoleGame/Game.cpp
@@ -1,5 +1,5 @@
 #include "Game.h"
-#include "GameConfig.h"
+#include "GameDefs.h"
 #include "ArenaDefs.h"
 #include "IGameEventAggregator.h"
 #include "IPlayerFactory.h"
@@ -13,15 +13,15 @@
 using namespace std;
 using namespace ConsoleGame;
 
-Game::Game( const std::shared_ptr<GameConfig> config,
+Game::Game( const std::shared_ptr<GameDefs> gameDefs,
             const std::shared_ptr<IGameEventAggregator> eventAggregator,
             const std::shared_ptr<IPlayerFactory> playerFactory ) :
-   _config( config ),
+   _gameDefs( gameDefs ),
    _eventAggregator( eventAggregator ),
    _player( playerFactory->CreatePlayer() ),
    _state( GameState::Startup ),
-   _arenaPlayerPositionX( config->ArenaDefs->PlayerStartX ),
-   _arenaPlayerPositionY( config->ArenaDefs->PlayerStartY ),
+   _arenaPlayerPositionX( gameDefs->ArenaDefs->PlayerStartX ),
+   _arenaPlayerPositionY( gameDefs->ArenaDefs->PlayerStartY ),
    _playerWasPushedX( false ),
    _playerWasPushedY( false )
 {
@@ -81,12 +81,12 @@ bool Game::IsPlayerMoving() const
 
 double Game::GetArenaWidth() const
 {
-   return _config->ArenaDefs->Width;
+   return _gameDefs->ArenaDefs->Width;
 }
 
 double Game::GetArenaHeight() const
 {
-   return _config->ArenaDefs->Height;
+   return _gameDefs->ArenaDefs->Height;
 }
 
 void Game::PushPlayer( Direction direction )
@@ -105,29 +105,29 @@ void Game::PushPlayer( Direction direction )
 
 void Game::MovePlayer()
 {
-   _arenaPlayerPositionX += ( _player->GetVelocityX() / _config->FramesPerSecond );
+   _arenaPlayerPositionX += ( _player->GetVelocityX() / _gameDefs->FramesPerSecond );
 
    if ( _arenaPlayerPositionX < 0. )
    {
       _arenaPlayerPositionX = 0.;
       _player->StopX();
    }
-   else if ( _arenaPlayerPositionX >= _config->ArenaDefs->Width )
+   else if ( _arenaPlayerPositionX >= _gameDefs->ArenaDefs->Width )
    {
-      _arenaPlayerPositionX = _config->ArenaDefs->Width - 1.;
+      _arenaPlayerPositionX = _gameDefs->ArenaDefs->Width - 1.;
       _player->StopX();
    }
 
-   _arenaPlayerPositionY += ( _player->GetVelocityY() / _config->FramesPerSecond );
+   _arenaPlayerPositionY += ( _player->GetVelocityY() / _gameDefs->FramesPerSecond );
 
    if ( _arenaPlayerPositionY < 0. )
    {
       _arenaPlayerPositionY = 0.;
       _player->StopY();
    }
-   else if ( _arenaPlayerPositionY >= _config->ArenaDefs->Height )
+   else if ( _arenaPlayerPositionY >= _gameDefs->ArenaDefs->Height )
    {
-      _arenaPlayerPositionY = _config->ArenaDefs->Height - 1.;
+      _arenaPlayerPositionY = _gameDefs->ArenaDefs->Height - 1.;
       _player->StopY();
    }
 }

--- a/ConsoleGame/Game.cpp
+++ b/ConsoleGame/Game.cpp
@@ -1,7 +1,7 @@
 #include "Game.h"
 #include "GameConfig.h"
 #include "PlayerConfig.h"
-#include "ArenaConfig.h"
+#include "ArenaDefs.h"
 #include "IGameEventAggregator.h"
 #include "IPlayerFactory.h"
 #include "IPlayer.h"
@@ -21,8 +21,8 @@ Game::Game( const std::shared_ptr<GameConfig> config,
    _eventAggregator( eventAggregator ),
    _player( playerFactory->CreatePlayer() ),
    _state( GameState::Startup ),
-   _arenaPlayerPositionX( config->ArenaConfig->PlayerStartX ),
-   _arenaPlayerPositionY( config->ArenaConfig->PlayerStartY ),
+   _arenaPlayerPositionX( config->ArenaDefs->PlayerStartX ),
+   _arenaPlayerPositionY( config->ArenaDefs->PlayerStartY ),
    _playerWasPushedX( false ),
    _playerWasPushedY( false )
 {
@@ -82,12 +82,12 @@ bool Game::IsPlayerMoving() const
 
 double Game::GetArenaWidth() const
 {
-   return _config->ArenaConfig->Width;
+   return _config->ArenaDefs->Width;
 }
 
 double Game::GetArenaHeight() const
 {
-   return _config->ArenaConfig->Height;
+   return _config->ArenaDefs->Height;
 }
 
 void Game::PushPlayer( Direction direction )
@@ -113,9 +113,9 @@ void Game::MovePlayer()
       _arenaPlayerPositionX = 0.;
       _player->StopX();
    }
-   else if ( _arenaPlayerPositionX >= _config->ArenaConfig->Width )
+   else if ( _arenaPlayerPositionX >= _config->ArenaDefs->Width )
    {
-      _arenaPlayerPositionX = _config->ArenaConfig->Width - 1.;
+      _arenaPlayerPositionX = _config->ArenaDefs->Width - 1.;
       _player->StopX();
    }
 
@@ -126,9 +126,9 @@ void Game::MovePlayer()
       _arenaPlayerPositionY = 0.;
       _player->StopY();
    }
-   else if ( _arenaPlayerPositionY >= _config->ArenaConfig->Height )
+   else if ( _arenaPlayerPositionY >= _config->ArenaDefs->Height )
    {
-      _arenaPlayerPositionY = _config->ArenaConfig->Height - 1.;
+      _arenaPlayerPositionY = _config->ArenaDefs->Height - 1.;
       _player->StopY();
    }
 }

--- a/ConsoleGame/Game.h
+++ b/ConsoleGame/Game.h
@@ -8,7 +8,7 @@
 
 namespace ConsoleGame
 {
-   class GameConfig;
+   class GameDefs;
    enum class Direction;
    class IGameEventAggregator;
    class IPlayerFactory;
@@ -19,7 +19,7 @@ namespace ConsoleGame
                 public IGameInfoProvider
    {
    public:
-      Game( const std::shared_ptr<GameConfig> config,
+      Game( const std::shared_ptr<GameDefs> gameDefs,
             const std::shared_ptr<IGameEventAggregator> eventAggregator,
             const std::shared_ptr<IPlayerFactory> playerFactory );
 
@@ -44,7 +44,7 @@ namespace ConsoleGame
       void MovePlayer();
 
    private:
-      const std::shared_ptr<GameConfig> _config;
+      const std::shared_ptr<GameDefs> _gameDefs;
       const std::shared_ptr<IGameEventAggregator> _eventAggregator;
       const std::shared_ptr<IPlayer> _player;
 

--- a/ConsoleGame/Game.h
+++ b/ConsoleGame/Game.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #include "IGame.h"
 #include "IGameCommandExecutor.h"
 #include "IGameInfoProvider.h"
@@ -9,7 +7,6 @@
 namespace ConsoleGame
 {
    class GameDefs;
-   enum class Direction;
    class IGameEventAggregator;
    class IPlayerFactory;
    class IPlayer;

--- a/ConsoleGame/GameConfig.h
+++ b/ConsoleGame/GameConfig.h
@@ -4,7 +4,7 @@
 
 namespace ConsoleGame
 {
-   class IGameRenderConfig;
+   class IGameRenderDefs;
    class IGameInputConfig;
    class PlayerConfig;
    class ArenaDefs;
@@ -15,7 +15,7 @@ namespace ConsoleGame
    public:
       int FramesPerSecond = 0;
 
-      std::shared_ptr<IGameRenderConfig> RenderConfig;
+      std::shared_ptr<IGameRenderDefs> RenderDefs;
       std::shared_ptr<IGameInputConfig> InputConfig;
       std::shared_ptr<PlayerConfig> PlayerConfig;
       std::shared_ptr<ArenaDefs> ArenaDefs;

--- a/ConsoleGame/GameConfig.h
+++ b/ConsoleGame/GameConfig.h
@@ -7,7 +7,7 @@ namespace ConsoleGame
    class IGameRenderConfig;
    class IGameInputConfig;
    class PlayerConfig;
-   class ArenaConfig;
+   class ArenaDefs;
    enum class Direction;
 
    class GameConfig
@@ -18,6 +18,6 @@ namespace ConsoleGame
       std::shared_ptr<IGameRenderConfig> RenderConfig;
       std::shared_ptr<IGameInputConfig> InputConfig;
       std::shared_ptr<PlayerConfig> PlayerConfig;
-      std::shared_ptr<ArenaConfig> ArenaConfig;
+      std::shared_ptr<ArenaDefs> ArenaDefs;
    };
 }

--- a/ConsoleGame/GameConfig.h
+++ b/ConsoleGame/GameConfig.h
@@ -6,7 +6,7 @@ namespace ConsoleGame
 {
    class IGameRenderDefs;
    class IGameInputDefs;
-   class PlayerConfig;
+   class PlayerDefs;
    class ArenaDefs;
    enum class Direction;
 
@@ -17,7 +17,7 @@ namespace ConsoleGame
 
       std::shared_ptr<IGameRenderDefs> RenderDefs;
       std::shared_ptr<IGameInputDefs> InputDefs;
-      std::shared_ptr<PlayerConfig> PlayerConfig;
+      std::shared_ptr<PlayerDefs> PlayerDefs;
       std::shared_ptr<ArenaDefs> ArenaDefs;
    };
 }

--- a/ConsoleGame/GameConfig.h
+++ b/ConsoleGame/GameConfig.h
@@ -5,7 +5,7 @@
 namespace ConsoleGame
 {
    class IGameRenderDefs;
-   class IGameInputConfig;
+   class IGameInputDefs;
    class PlayerConfig;
    class ArenaDefs;
    enum class Direction;
@@ -16,7 +16,7 @@ namespace ConsoleGame
       int FramesPerSecond = 0;
 
       std::shared_ptr<IGameRenderDefs> RenderDefs;
-      std::shared_ptr<IGameInputConfig> InputConfig;
+      std::shared_ptr<IGameInputDefs> InputDefs;
       std::shared_ptr<PlayerConfig> PlayerConfig;
       std::shared_ptr<ArenaDefs> ArenaDefs;
    };

--- a/ConsoleGame/GameDefs.h
+++ b/ConsoleGame/GameDefs.h
@@ -8,7 +8,6 @@ namespace ConsoleGame
    class IGameInputDefs;
    class PlayerDefs;
    class ArenaDefs;
-   enum class Direction;
 
    class GameDefs
    {

--- a/ConsoleGame/GameDefs.h
+++ b/ConsoleGame/GameDefs.h
@@ -10,7 +10,7 @@ namespace ConsoleGame
    class ArenaDefs;
    enum class Direction;
 
-   class GameConfig
+   class GameDefs
    {
    public:
       int FramesPerSecond = 0;

--- a/ConsoleGame/GameEventAggregator.cpp
+++ b/ConsoleGame/GameEventAggregator.cpp
@@ -1,5 +1,4 @@
 #include "GameEventAggregator.h"
-#include "GameEvent.h"
 
 using namespace std;
 using namespace ConsoleGame;

--- a/ConsoleGame/GameEventAggregator.h
+++ b/ConsoleGame/GameEventAggregator.h
@@ -7,8 +7,6 @@
 
 namespace ConsoleGame
 {
-   enum class GameEvent;
-
    class GameEventAggregator : public IGameEventAggregator
    {
    public:

--- a/ConsoleGame/GameInputHandler.cpp
+++ b/ConsoleGame/GameInputHandler.cpp
@@ -2,9 +2,6 @@
 #include "IGameInputReader.h"
 #include "IGameInfoProvider.h"
 #include "IGameEventAggregator.h"
-#include "GameButton.h"
-#include "GameEvent.h"
-#include "GameState.h"
 
 using namespace std;
 using namespace ConsoleGame;

--- a/ConsoleGame/GameInputHandler.h
+++ b/ConsoleGame/GameInputHandler.h
@@ -4,13 +4,13 @@
 #include <map>
 
 #include "IGameInputHandler.h"
+#include "GameState.h"
 
 namespace ConsoleGame
 {
    class IGameInputReader;
    class IGameInfoProvider;
    class IGameEventAggregator;
-   enum class GameState;
 
    class GameInputHandler : public IGameInputHandler
    {

--- a/ConsoleGame/GameRenderer.cpp
+++ b/ConsoleGame/GameRenderer.cpp
@@ -1,7 +1,7 @@
 #include <format>
 
 #include "GameRenderer.h"
-#include "ConsoleRenderConfig.h"
+#include "ConsoleRenderDefs.h"
 #include "IScreenBuffer.h"
 #include "IGameInfoProvider.h"
 #include "IGameEventAggregator.h"
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace ConsoleGame;
 
-GameRenderer::GameRenderer( const shared_ptr<ConsoleRenderConfig> renderConfig,
+GameRenderer::GameRenderer( const shared_ptr<ConsoleRenderDefs> renderDefs,
                             const shared_ptr<IScreenBuffer> screenBuffer,
                             const shared_ptr<IGameInfoProvider> gameInfoProvider,
                             const shared_ptr<IGameRenderer> diagnosticsRenderer,
@@ -26,7 +26,7 @@ GameRenderer::GameRenderer( const shared_ptr<ConsoleRenderConfig> renderConfig,
    eventAggregator->RegisterEventHandler( GameEvent::Shutdown, std::bind( &GameRenderer::HandleShutdownEvent, this ) );
    eventAggregator->RegisterEventHandler( GameEvent::ToggleDiagnostics, std::bind( &GameRenderer::HandleToggleDiagnosticsEvent, this ) );
 
-   _screenBuffer->LoadRenderConfig( renderConfig );
+   _screenBuffer->LoadRenderDefs( renderDefs );
 }
 
 void GameRenderer::AddRendererForGameState( GameState state, shared_ptr<IGameRenderer> renderer )

--- a/ConsoleGame/GameRenderer.cpp
+++ b/ConsoleGame/GameRenderer.cpp
@@ -5,9 +5,6 @@
 #include "IScreenBuffer.h"
 #include "IGameInfoProvider.h"
 #include "IGameEventAggregator.h"
-#include "GameState.h"
-#include "GameEvent.h"
-#include "ConsoleColor.h"
 
 using namespace std;
 using namespace ConsoleGame;

--- a/ConsoleGame/GameRenderer.h
+++ b/ConsoleGame/GameRenderer.h
@@ -8,7 +8,7 @@
 
 namespace ConsoleGame
 {
-   class ConsoleRenderConfig;
+   class ConsoleRenderDefs;
    class IScreenBuffer;
    class IGameInfoProvider;
    class IGameEventAggregator;
@@ -18,7 +18,7 @@ namespace ConsoleGame
    class GameRenderer : public IGameRenderer
    {
    public:
-      GameRenderer( const std::shared_ptr<ConsoleRenderConfig> renderConfig,
+      GameRenderer( const std::shared_ptr<ConsoleRenderDefs> renderDefs,
                     const std::shared_ptr<IScreenBuffer> screenBuffer,
                     const std::shared_ptr<IGameInfoProvider> gameInfoProvider,
                     const std::shared_ptr<IGameRenderer> diagnosticsRenderer,

--- a/ConsoleGame/GameRenderer.h
+++ b/ConsoleGame/GameRenderer.h
@@ -4,6 +4,7 @@
 #include <map>
 
 #include "IGameRenderer.h"
+#include "GameState.h"
 #include "GameEvent.h"
 
 namespace ConsoleGame
@@ -12,8 +13,6 @@ namespace ConsoleGame
    class IScreenBuffer;
    class IGameInfoProvider;
    class IGameEventAggregator;
-   enum class GameState;
-   enum class GameEvent;
 
    class GameRenderer : public IGameRenderer
    {

--- a/ConsoleGame/GameRunner.cpp
+++ b/ConsoleGame/GameRunner.cpp
@@ -5,7 +5,6 @@
 #include "IGameRenderer.h"
 #include "IGame.h"
 #include "IThread.h"
-#include "GameEvent.h"
 
 using namespace ConsoleGame;
 

--- a/ConsoleGame/IConsoleBuffer.h
+++ b/ConsoleGame/IConsoleBuffer.h
@@ -3,12 +3,11 @@
 #include <string>
 
 #include "IScreenBuffer.h"
+#include "ConsoleSprite.h"
+#include "ConsoleColor.h"
 
 namespace ConsoleGame
 {
-   enum class ConsoleColor;
-   struct ConsoleSprite;
-
    class __declspec( novtable ) IConsoleBuffer : public IScreenBuffer
    {
    public:

--- a/ConsoleGame/IConsoleBuffer.h
+++ b/ConsoleGame/IConsoleBuffer.h
@@ -12,7 +12,7 @@ namespace ConsoleGame
    class __declspec( novtable ) IConsoleBuffer : public IScreenBuffer
    {
    public:
-      virtual void LoadRenderConfig( std::shared_ptr<IGameRenderConfig> config ) override = 0;
+      virtual void LoadRenderDefs( std::shared_ptr<IGameRenderDefs> renderDefs ) override = 0;
       virtual void CleanUp() override = 0;
 
       virtual void SetDefaultForegroundColor( ConsoleColor color ) = 0;

--- a/ConsoleGame/IGameCommandExecutor.h
+++ b/ConsoleGame/IGameCommandExecutor.h
@@ -2,9 +2,10 @@
 
 #include <memory>
 
+#include "GameCommand.h"
+
 namespace ConsoleGame
 {
-   enum class GameCommand;
    class GameCommandArgs;
 
    class _declspec( novtable ) IGameCommandExecutor

--- a/ConsoleGame/IGameEventAggregator.h
+++ b/ConsoleGame/IGameEventAggregator.h
@@ -2,10 +2,10 @@
 
 #include <functional>
 
+#include "GameEvent.h"
+
 namespace ConsoleGame
 {
-   enum class GameEvent;
-
    class __declspec( novtable ) IGameEventAggregator
    {
    public:

--- a/ConsoleGame/IGameInfoProvider.h
+++ b/ConsoleGame/IGameInfoProvider.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "GameState.h"
+#include "Direction.h"
+
 namespace ConsoleGame
 {
-   enum class GameState;
-   enum class Direction;
-
    class __declspec( novtable ) IGameInfoProvider
    {
    public:

--- a/ConsoleGame/IGameInputConfig.h
+++ b/ConsoleGame/IGameInputConfig.h
@@ -1,6 +1,0 @@
-#pragma once
-
-namespace ConsoleGame
-{
-   class __declspec( novtable ) IGameInputConfig { };
-}

--- a/ConsoleGame/IGameInputDefs.h
+++ b/ConsoleGame/IGameInputDefs.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace ConsoleGame
+{
+   class __declspec( novtable ) IGameInputDefs { };
+}

--- a/ConsoleGame/IGameInputReader.h
+++ b/ConsoleGame/IGameInputReader.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "GameButton.h"
+
 namespace ConsoleGame
 {
-   enum class GameButton;
-
    class __declspec( novtable ) IGameInputReader
    {
    public:

--- a/ConsoleGame/IGameRenderConfig.h
+++ b/ConsoleGame/IGameRenderConfig.h
@@ -1,6 +1,0 @@
-#pragma once
-
-namespace ConsoleGame
-{
-   class _declspec(novtable) IGameRenderConfig { };
-}

--- a/ConsoleGame/IGameRenderDefs.h
+++ b/ConsoleGame/IGameRenderDefs.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace ConsoleGame
+{
+   class _declspec(novtable) IGameRenderDefs { };
+}

--- a/ConsoleGame/IKeyboard.h
+++ b/ConsoleGame/IKeyboard.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "KeyCode.h"
+
 namespace ConsoleGame
 {
-   enum class KeyCode;
-
    class __declspec( novtable ) IKeyboard
    {
    public:

--- a/ConsoleGame/IScreenBuffer.h
+++ b/ConsoleGame/IScreenBuffer.h
@@ -4,12 +4,12 @@
 
 namespace ConsoleGame
 {
-   class IGameRenderConfig;
+   class IGameRenderDefs;
 
    class __declspec( novtable ) IScreenBuffer
    {
    public:
-      virtual void LoadRenderConfig( const std::shared_ptr<IGameRenderConfig> config ) = 0;
+      virtual void LoadRenderDefs( const std::shared_ptr<IGameRenderDefs> renderDefs ) = 0;
       virtual void CleanUp() = 0;
 
       virtual void Clear() = 0;

--- a/ConsoleGame/KeyboardInputDefs.h
+++ b/ConsoleGame/KeyboardInputDefs.h
@@ -4,12 +4,11 @@
 #include <string>
 
 #include "IGameInputDefs.h"
+#include "KeyCode.h"
+#include "GameButton.h"
 
 namespace ConsoleGame
 {
-   enum class KeyCode;
-   enum class GameButton;
-
    class KeyboardInputDefs : public IGameInputDefs
    {
    public:

--- a/ConsoleGame/KeyboardInputDefs.h
+++ b/ConsoleGame/KeyboardInputDefs.h
@@ -3,14 +3,14 @@
 #include <map>
 #include <string>
 
-#include "IGameInputConfig.h"
+#include "IGameInputDefs.h"
 
 namespace ConsoleGame
 {
    enum class KeyCode;
    enum class GameButton;
 
-   class KeyboardInputConfig : public IGameInputConfig
+   class KeyboardInputDefs : public IGameInputDefs
    {
    public:
       std::map<KeyCode, GameButton> KeyMap;

--- a/ConsoleGame/KeyboardInputReader.cpp
+++ b/ConsoleGame/KeyboardInputReader.cpp
@@ -1,5 +1,5 @@
 #include "KeyboardInputReader.h"
-#include "KeyboardInputConfig.h"
+#include "KeyboardInputDefs.h"
 #include "IKeyboard.h"
 #include "KeyCode.h"
 #include "GameButton.h"
@@ -7,7 +7,7 @@
 using namespace std;
 using namespace ConsoleGame;
 
-KeyboardInputReader::KeyboardInputReader( const shared_ptr<KeyboardInputConfig> inputConfig,
+KeyboardInputReader::KeyboardInputReader( const shared_ptr<KeyboardInputDefs> inputDefs,
                                           const shared_ptr<IKeyboard> keyboard ) :
    _keyboard( keyboard )
 {
@@ -22,7 +22,7 @@ KeyboardInputReader::KeyboardInputReader( const shared_ptr<KeyboardInputConfig> 
    {
       auto button = (GameButton)i;
 
-      for ( auto const& [keyCode, mappedButton] : inputConfig->KeyMap )
+      for ( auto const& [keyCode, mappedButton] : inputDefs->KeyMap )
       {
          if ( mappedButton == button )
          {

--- a/ConsoleGame/KeyboardInputReader.cpp
+++ b/ConsoleGame/KeyboardInputReader.cpp
@@ -1,8 +1,6 @@
 #include "KeyboardInputReader.h"
 #include "KeyboardInputDefs.h"
 #include "IKeyboard.h"
-#include "KeyCode.h"
-#include "GameButton.h"
 
 using namespace std;
 using namespace ConsoleGame;

--- a/ConsoleGame/KeyboardInputReader.h
+++ b/ConsoleGame/KeyboardInputReader.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "IGameInputReader.h"
+#include "KeyCode.h"
 
 namespace ConsoleGame
 {
@@ -16,8 +17,6 @@ namespace ConsoleGame
 
    class KeyboardInputDefs;
    class IKeyboard;
-   enum class KeyCode;
-   enum class GameButton;
 
    class KeyboardInputReader : public IGameInputReader
    {

--- a/ConsoleGame/KeyboardInputReader.h
+++ b/ConsoleGame/KeyboardInputReader.h
@@ -14,7 +14,7 @@ namespace ConsoleGame
       bool ButtonIsDown;
    };
 
-   class KeyboardInputConfig;
+   class KeyboardInputDefs;
    class IKeyboard;
    enum class KeyCode;
    enum class GameButton;
@@ -22,7 +22,7 @@ namespace ConsoleGame
    class KeyboardInputReader : public IGameInputReader
    {
    public:
-      KeyboardInputReader( const std::shared_ptr<KeyboardInputConfig> inputConfig,
+      KeyboardInputReader( const std::shared_ptr<KeyboardInputDefs> inputDefs,
                            const std::shared_ptr<IKeyboard> keyboard );
 
       void ReadInput() override;

--- a/ConsoleGame/KeyboardWrapper.cpp
+++ b/ConsoleGame/KeyboardWrapper.cpp
@@ -2,7 +2,6 @@
 #include <Windows.h>
 
 #include "KeyboardWrapper.h"
-#include "KeyCode.h"
 
 using namespace ConsoleGame;
 

--- a/ConsoleGame/Player.cpp
+++ b/ConsoleGame/Player.cpp
@@ -1,18 +1,18 @@
 #include <algorithm>
 
 #include "Player.h"
-#include "PlayerConfig.h"
+#include "PlayerDefs.h"
 
 using namespace std;
 using namespace ConsoleGame;
 
-Player::Player( const shared_ptr<PlayerConfig> config,
+Player::Player( const shared_ptr<PlayerDefs> playerDefs,
                 int framesPerSecond ) :
-   _config( config ),
-   _velocityX( _config->StartVelocityX ),
-   _velocityY( _config->StartVelocityY ),
-   _velocityDelta( _config->AccelerationPerSecond / framesPerSecond ),
-   _direction( _config->StartDirection )
+   _playerDefs( playerDefs ),
+   _velocityX( _playerDefs->StartVelocityX ),
+   _velocityY( _playerDefs->StartVelocityY ),
+   _velocityDelta( _playerDefs->AccelerationPerSecond / framesPerSecond ),
+   _direction( _playerDefs->StartDirection )
 {
 }
 
@@ -91,21 +91,21 @@ void Player::StopY()
 
 void Player::ClampVelocity()
 {
-   if ( _velocityX < -( _config->MaxVelocity ) )
+   if ( _velocityX < -( _playerDefs->MaxVelocity ) )
    {
-      _velocityX = -( _config->MaxVelocity );
+      _velocityX = -( _playerDefs->MaxVelocity );
    }
-   else if ( _velocityX > _config->MaxVelocity )
+   else if ( _velocityX > _playerDefs->MaxVelocity )
    {
-      _velocityX = _config->MaxVelocity;
+      _velocityX = _playerDefs->MaxVelocity;
    }
 
-   if ( _velocityY < -( _config->MaxVelocity ) )
+   if ( _velocityY < -( _playerDefs->MaxVelocity ) )
    {
-      _velocityY = -( _config->MaxVelocity );
+      _velocityY = -( _playerDefs->MaxVelocity );
    }
-   else if ( _velocityY > _config->MaxVelocity )
+   else if ( _velocityY > _playerDefs->MaxVelocity )
    {
-      _velocityY = _config->MaxVelocity;
+      _velocityY = _playerDefs->MaxVelocity;
    }
 }

--- a/ConsoleGame/Player.h
+++ b/ConsoleGame/Player.h
@@ -6,12 +6,12 @@
 
 namespace ConsoleGame
 {
-   class PlayerConfig;
+   class PlayerDefs;
 
    class Player : public IPlayer
    {
    public:
-      Player( const std::shared_ptr<PlayerConfig> config,
+      Player( const std::shared_ptr<PlayerDefs> playerDefs,
               int framesPerSecond );
 
       void Push( Direction direction ) override;
@@ -29,7 +29,7 @@ namespace ConsoleGame
       void ClampVelocity();
 
    private:
-      const std::shared_ptr<PlayerConfig> _config;
+      const std::shared_ptr<PlayerDefs> _playerDefs;
 
       double _velocityX;
       double _velocityY;

--- a/ConsoleGame/PlayerDefs.h
+++ b/ConsoleGame/PlayerDefs.h
@@ -4,7 +4,7 @@
 
 namespace ConsoleGame
 {
-   class PlayerConfig
+   class PlayerDefs
    {
    public:
       double StartVelocityX = 0.;

--- a/ConsoleGame/PlayerFactory.cpp
+++ b/ConsoleGame/PlayerFactory.cpp
@@ -1,16 +1,16 @@
 #include "PlayerFactory.h"
 #include "Player.h"
-#include "GameConfig.h"
+#include "GameDefs.h"
 
 using namespace std;
 using namespace ConsoleGame;
 
-PlayerFactory::PlayerFactory( const shared_ptr<GameConfig> config ) :
-   _config( config )
+PlayerFactory::PlayerFactory( const shared_ptr<GameDefs> gameDefs ) :
+   _gameDefs( gameDefs )
 {
 }
 
 const shared_ptr<IPlayer> PlayerFactory::CreatePlayer() const
 {
-   return shared_ptr<IPlayer>( new Player( _config->PlayerDefs, _config->FramesPerSecond ) );
+   return shared_ptr<IPlayer>( new Player( _gameDefs->PlayerDefs, _gameDefs->FramesPerSecond ) );
 }

--- a/ConsoleGame/PlayerFactory.cpp
+++ b/ConsoleGame/PlayerFactory.cpp
@@ -12,5 +12,5 @@ PlayerFactory::PlayerFactory( const shared_ptr<GameConfig> config ) :
 
 const shared_ptr<IPlayer> PlayerFactory::CreatePlayer() const
 {
-   return shared_ptr<IPlayer>( new Player( _config->PlayerConfig, _config->FramesPerSecond ) );
+   return shared_ptr<IPlayer>( new Player( _config->PlayerDefs, _config->FramesPerSecond ) );
 }

--- a/ConsoleGame/PlayerFactory.h
+++ b/ConsoleGame/PlayerFactory.h
@@ -6,16 +6,16 @@
 
 namespace ConsoleGame
 {
-   class GameConfig;
+   class GameDefs;
 
    class PlayerFactory : public IPlayerFactory
    {
    public:
-      PlayerFactory( const std::shared_ptr<GameConfig> config );
+      PlayerFactory( const std::shared_ptr<GameDefs> gameDefs );
 
       const std::shared_ptr<IPlayer> CreatePlayer() const override;
 
    private:
-      const std::shared_ptr<GameConfig> _config;
+      const std::shared_ptr<GameDefs> _gameDefs;
    };
 }

--- a/ConsoleGame/PlayerFactory.h
+++ b/ConsoleGame/PlayerFactory.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #include "IPlayerFactory.h"
 
 namespace ConsoleGame

--- a/ConsoleGame/PlayingStateConsoleRenderer.cpp
+++ b/ConsoleGame/PlayingStateConsoleRenderer.cpp
@@ -2,10 +2,6 @@
 #include "IConsoleBuffer.h"
 #include "ConsoleRenderDefs.h"
 #include "IGameInfoProvider.h"
-#include "ConsoleColor.h"
-#include "Direction.h"
-#include "ConsoleSprite.h"
-#include "ConsolePixel.h"
 
 using namespace std;
 using namespace ConsoleGame;

--- a/ConsoleGame/PlayingStateConsoleRenderer.cpp
+++ b/ConsoleGame/PlayingStateConsoleRenderer.cpp
@@ -1,6 +1,6 @@
 #include "PlayingStateConsoleRenderer.h"
 #include "IConsoleBuffer.h"
-#include "ConsoleRenderConfig.h"
+#include "ConsoleRenderDefs.h"
 #include "IGameInfoProvider.h"
 #include "ConsoleColor.h"
 #include "Direction.h"
@@ -11,13 +11,13 @@ using namespace std;
 using namespace ConsoleGame;
 
 PlayingStateConsoleRenderer::PlayingStateConsoleRenderer( const shared_ptr<IConsoleBuffer> consoleBuffer,
-                                                          const shared_ptr<ConsoleRenderConfig> renderConfig,
+                                                          const shared_ptr<ConsoleRenderDefs> renderDefs,
                                                           const shared_ptr<IGameInfoProvider> gameInfoProvider ) :
    _consoleBuffer( consoleBuffer ),
-   _renderConfig( renderConfig ),
+   _renderDefs( renderDefs ),
    _gameInfoProvider( gameInfoProvider ),
-   _arenaCoordConverterX( renderConfig->ArenaCharWidth / gameInfoProvider->GetArenaWidth() ),
-   _arenaCoordConverterY( renderConfig->ArenaCharHeight / gameInfoProvider->GetArenaHeight() )
+   _arenaCoordConverterX( renderDefs->ArenaCharWidth / gameInfoProvider->GetArenaWidth() ),
+   _arenaCoordConverterY( renderDefs->ArenaCharHeight / gameInfoProvider->GetArenaHeight() )
 {
 }
 
@@ -35,23 +35,23 @@ void PlayingStateConsoleRenderer::Render()
 void PlayingStateConsoleRenderer::DrawArenaFence()
 {
    // corners
-   _consoleBuffer->Draw( _renderConfig->ArenaFenceX, _renderConfig->ArenaFenceY, ',');
-   _consoleBuffer->Draw( _renderConfig->ArenaFenceX + _renderConfig->ArenaCharWidth + 1, _renderConfig->ArenaFenceY, '.' );
-   _consoleBuffer->Draw( _renderConfig->ArenaFenceX, _renderConfig->ArenaFenceY + _renderConfig->ArenaCharHeight + 1, '\'' );
-   _consoleBuffer->Draw( _renderConfig->ArenaFenceX + _renderConfig->ArenaCharWidth + 1, _renderConfig->ArenaFenceY + _renderConfig->ArenaCharHeight + 1, '\'' );
+   _consoleBuffer->Draw( _renderDefs->ArenaFenceX, _renderDefs->ArenaFenceY, ',');
+   _consoleBuffer->Draw( _renderDefs->ArenaFenceX + _renderDefs->ArenaCharWidth + 1, _renderDefs->ArenaFenceY, '.' );
+   _consoleBuffer->Draw( _renderDefs->ArenaFenceX, _renderDefs->ArenaFenceY + _renderDefs->ArenaCharHeight + 1, '\'' );
+   _consoleBuffer->Draw( _renderDefs->ArenaFenceX + _renderDefs->ArenaCharWidth + 1, _renderDefs->ArenaFenceY + _renderDefs->ArenaCharHeight + 1, '\'' );
 
    // top and bottom fences
-   for ( int left = _renderConfig->ArenaFenceX; left < _renderConfig->ArenaCharWidth + 1; left++ )
+   for ( int left = _renderDefs->ArenaFenceX; left < _renderDefs->ArenaCharWidth + 1; left++ )
    {
-      _consoleBuffer->Draw( left + 1, _renderConfig->ArenaFenceY, '-' );
-      _consoleBuffer->Draw( left + 1, _renderConfig->ArenaFenceY + _renderConfig->ArenaCharHeight + 1, '-' );
+      _consoleBuffer->Draw( left + 1, _renderDefs->ArenaFenceY, '-' );
+      _consoleBuffer->Draw( left + 1, _renderDefs->ArenaFenceY + _renderDefs->ArenaCharHeight + 1, '-' );
    }
 
    // side fences
-   for ( int top = _renderConfig->ArenaFenceY + 1; top < _renderConfig->ArenaFenceY + _renderConfig->ArenaCharHeight + 1; top++ )
+   for ( int top = _renderDefs->ArenaFenceY + 1; top < _renderDefs->ArenaFenceY + _renderDefs->ArenaCharHeight + 1; top++ )
    {
-      _consoleBuffer->Draw( _renderConfig->ArenaFenceX, top, '|' );
-      _consoleBuffer->Draw( _renderConfig->ArenaFenceX + _renderConfig->ArenaCharWidth + 1, top, '|' );
+      _consoleBuffer->Draw( _renderDefs->ArenaFenceX, top, '|' );
+      _consoleBuffer->Draw( _renderDefs->ArenaFenceX + _renderDefs->ArenaCharWidth + 1, top, '|' );
    }
 }
 
@@ -60,12 +60,12 @@ void PlayingStateConsoleRenderer::DrawPlayer()
    auto convertedPlayerX = (short)( _gameInfoProvider->GetArenaPlayerXPosition() * _arenaCoordConverterX );
    auto convertedPlayerY = (short)( _gameInfoProvider->GetArenaPlayerYPosition() * _arenaCoordConverterY );
 
-   auto playerX = convertedPlayerX + _renderConfig->ArenaFenceX + 1;
-   auto playerY = convertedPlayerY + _renderConfig->ArenaFenceY + 1;
+   auto playerX = convertedPlayerX + _renderDefs->ArenaFenceX + 1;
+   auto playerY = convertedPlayerY + _renderDefs->ArenaFenceY + 1;
 
    if ( !_gameInfoProvider->IsPlayerMoving() )
    {
-      _consoleBuffer->Draw( playerX, playerY, _renderConfig->PlayerStaticSprite );
+      _consoleBuffer->Draw( playerX, playerY, _renderDefs->PlayerStaticSprite );
       return;
    }
 
@@ -90,5 +90,5 @@ void PlayingStateConsoleRenderer::DrawPlayer()
       break;
    }
 
-   _consoleBuffer->Draw( playerX + spriteOffsetX, playerY + spriteOffsetY, _renderConfig->PlayerMovingSpriteMap[direction] );
+   _consoleBuffer->Draw( playerX + spriteOffsetX, playerY + spriteOffsetY, _renderDefs->PlayerMovingSpriteMap[direction] );
 }

--- a/ConsoleGame/PlayingStateConsoleRenderer.h
+++ b/ConsoleGame/PlayingStateConsoleRenderer.h
@@ -7,14 +7,14 @@
 namespace ConsoleGame
 {
    class IConsoleBuffer;
-   class ConsoleRenderConfig;
+   class ConsoleRenderDefs;
    class IGameInfoProvider;
 
    class PlayingStateConsoleRenderer : public IGameRenderer
    {
    public:
       PlayingStateConsoleRenderer( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
-                                   const std::shared_ptr<ConsoleRenderConfig> renderConfig,
+                                   const std::shared_ptr<ConsoleRenderDefs> renderDefs,
                                    const std::shared_ptr<IGameInfoProvider> gameInfoProvider );
 
       void Render() override;
@@ -25,7 +25,7 @@ namespace ConsoleGame
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
-      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
+      const std::shared_ptr<ConsoleRenderDefs> _renderDefs;
       const std::shared_ptr<IGameInfoProvider> _gameInfoProvider;
 
       double _arenaCoordConverterX;

--- a/ConsoleGame/PlayingStateInputHandler.cpp
+++ b/ConsoleGame/PlayingStateInputHandler.cpp
@@ -1,10 +1,7 @@
 #include "PlayingStateInputHandler.h"
 #include "IGameInputReader.h"
 #include "IGameCommandExecutor.h"
-#include "GameButton.h"
-#include "GameCommand.h"
 #include "PushPlayerCommandArgs.h"
-#include "Direction.h"
 
 using namespace std;
 using namespace ConsoleGame;

--- a/ConsoleGame/PushPlayerCommandArgs.h
+++ b/ConsoleGame/PushPlayerCommandArgs.h
@@ -1,16 +1,15 @@
 #pragma once
 
 #include "GameCommandArgs.h"
+#include "Direction.h"
 
 namespace ConsoleGame
 {
-   enum class Direction;
-
    class PushPlayerCommandArgs : public GameCommandArgs
    {
    public:
-      PushPlayerCommandArgs( Direction direction )
-         : Direction ( direction )
+      PushPlayerCommandArgs( Direction direction ) :
+         Direction ( direction )
       { }
 
       Direction Direction;

--- a/ConsoleGame/StartupStateConsoleRenderer.cpp
+++ b/ConsoleGame/StartupStateConsoleRenderer.cpp
@@ -1,11 +1,9 @@
-#include <string>
 #include <format>
 
 #include "StartupStateConsoleRenderer.h"
 #include "IConsoleBuffer.h"
 #include "ConsoleRenderDefs.h"
 #include "KeyboardInputDefs.h"
-#include "ConsoleColor.h"
 
 using namespace std;
 using namespace ConsoleGame;

--- a/ConsoleGame/StartupStateConsoleRenderer.cpp
+++ b/ConsoleGame/StartupStateConsoleRenderer.cpp
@@ -3,7 +3,7 @@
 
 #include "StartupStateConsoleRenderer.h"
 #include "IConsoleBuffer.h"
-#include "ConsoleRenderConfig.h"
+#include "ConsoleRenderDefs.h"
 #include "KeyboardInputConfig.h"
 #include "ConsoleColor.h"
 
@@ -11,10 +11,10 @@ using namespace std;
 using namespace ConsoleGame;
 
 StartupStateConsoleRenderer::StartupStateConsoleRenderer( const shared_ptr<IConsoleBuffer> consoleBuffer,
-                                                          const shared_ptr<ConsoleRenderConfig> renderConfig,
+                                                          const shared_ptr<ConsoleRenderDefs> renderDefs,
                                                           const shared_ptr<KeyboardInputConfig> inputConfig ) :
    _consoleBuffer( consoleBuffer ),
-   _renderConfig( renderConfig ),
+   _renderDefs( renderDefs ),
    _inputConfig( inputConfig )
 {
 }
@@ -24,7 +24,7 @@ void StartupStateConsoleRenderer::Render()
    _consoleBuffer->SetDefaultBackgroundColor( ConsoleColor::DarkBlue );
    _consoleBuffer->SetDefaultForegroundColor( ConsoleColor::White );
 
-   auto middleX = _renderConfig->ConsoleWidth / 2;
+   auto middleX = _renderDefs->ConsoleWidth / 2;
 
    _consoleBuffer->Draw( middleX - 26, 1, ".==================================================." );
    _consoleBuffer->Draw( middleX - 27, 2, "|          WELCOME TO (INSERT YOUR TITLE)!!          |" );

--- a/ConsoleGame/StartupStateConsoleRenderer.cpp
+++ b/ConsoleGame/StartupStateConsoleRenderer.cpp
@@ -4,7 +4,7 @@
 #include "StartupStateConsoleRenderer.h"
 #include "IConsoleBuffer.h"
 #include "ConsoleRenderDefs.h"
-#include "KeyboardInputConfig.h"
+#include "KeyboardInputDefs.h"
 #include "ConsoleColor.h"
 
 using namespace std;
@@ -12,10 +12,10 @@ using namespace ConsoleGame;
 
 StartupStateConsoleRenderer::StartupStateConsoleRenderer( const shared_ptr<IConsoleBuffer> consoleBuffer,
                                                           const shared_ptr<ConsoleRenderDefs> renderDefs,
-                                                          const shared_ptr<KeyboardInputConfig> inputConfig ) :
+                                                          const shared_ptr<KeyboardInputDefs> inputDefs ) :
    _consoleBuffer( consoleBuffer ),
    _renderDefs( renderDefs ),
-   _inputConfig( inputConfig )
+   _inputDefs( inputDefs )
 {
 }
 
@@ -37,7 +37,7 @@ void StartupStateConsoleRenderer::Render()
 
    DrawKeyBindings( middleX, top );
 
-   top += (int)_inputConfig->KeyMap.size() + 1;
+   top += (int)_inputDefs->KeyMap.size() + 1;
    _consoleBuffer->Draw( middleX - 17, top, "Press any button to play the game!" );
    _consoleBuffer->Draw( middleX - 25, top + 1, "(remember, not every key is bound to a button....)" );
 }
@@ -46,10 +46,10 @@ void StartupStateConsoleRenderer::DrawKeyBindings( int middleX, int top ) const
 {
    auto leftOfMiddleX = middleX - 2;
 
-   for ( auto const& [keyCode, mappedButton] : _inputConfig->KeyMap )
+   for ( auto const& [keyCode, mappedButton] : _inputDefs->KeyMap )
    {
-      string keyString( format( "{0} Key", _inputConfig->KeyNames.at(keyCode) ) );
-      string buttonString( format( "{0} Button", _inputConfig->ButtonNames.at(mappedButton) ) );
+      string keyString( format( "{0} Key", _inputDefs->KeyNames.at(keyCode) ) );
+      string buttonString( format( "{0} Button", _inputDefs->ButtonNames.at(mappedButton) ) );
 
       _consoleBuffer->Draw( leftOfMiddleX - (int)keyString.length() - 2, top, format( "{0} -> {1}", keyString, buttonString ) );
 

--- a/ConsoleGame/StartupStateConsoleRenderer.h
+++ b/ConsoleGame/StartupStateConsoleRenderer.h
@@ -8,14 +8,14 @@ namespace ConsoleGame
 {
    class IConsoleBuffer;
    class ConsoleRenderDefs;
-   class KeyboardInputConfig;
+   class KeyboardInputDefs;
 
    class StartupStateConsoleRenderer : public IGameRenderer
    {
    public:
       StartupStateConsoleRenderer( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
                                    const std::shared_ptr<ConsoleRenderDefs> renderDefs,
-                                   const std::shared_ptr<KeyboardInputConfig> inputConfig );
+                                   const std::shared_ptr<KeyboardInputDefs> inputDefs );
 
       void Render() override;
 
@@ -25,6 +25,6 @@ namespace ConsoleGame
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
       const std::shared_ptr<ConsoleRenderDefs> _renderDefs;
-      const std::shared_ptr<KeyboardInputConfig> _inputConfig;
+      const std::shared_ptr<KeyboardInputDefs> _inputDefs;
    };
 }

--- a/ConsoleGame/StartupStateConsoleRenderer.h
+++ b/ConsoleGame/StartupStateConsoleRenderer.h
@@ -7,14 +7,14 @@
 namespace ConsoleGame
 {
    class IConsoleBuffer;
-   class ConsoleRenderConfig;
+   class ConsoleRenderDefs;
    class KeyboardInputConfig;
 
    class StartupStateConsoleRenderer : public IGameRenderer
    {
    public:
       StartupStateConsoleRenderer( const std::shared_ptr<IConsoleBuffer> consoleBuffer,
-                                   const std::shared_ptr<ConsoleRenderConfig> renderConfig,
+                                   const std::shared_ptr<ConsoleRenderDefs> renderDefs,
                                    const std::shared_ptr<KeyboardInputConfig> inputConfig );
 
       void Render() override;
@@ -24,7 +24,7 @@ namespace ConsoleGame
 
    private:
       const std::shared_ptr<IConsoleBuffer> _consoleBuffer;
-      const std::shared_ptr<ConsoleRenderConfig> _renderConfig;
+      const std::shared_ptr<ConsoleRenderDefs> _renderDefs;
       const std::shared_ptr<KeyboardInputConfig> _inputConfig;
    };
 }

--- a/ConsoleGame/StartupStateInputHandler.cpp
+++ b/ConsoleGame/StartupStateInputHandler.cpp
@@ -1,7 +1,6 @@
 #include "StartupStateInputHandler.h"
 #include "IGameInputReader.h"
 #include "IGameCommandExecutor.h"
-#include "GameCommand.h"
 
 using namespace std;
 using namespace ConsoleGame;

--- a/ConsoleGameTests/GameEventAggregatorTests.cpp
+++ b/ConsoleGameTests/GameEventAggregatorTests.cpp
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include <ConsoleGame/GameEventAggregator.h>
-#include <ConsoleGame/GameEvent.h>
 
 using namespace std;
 using namespace testing;

--- a/ConsoleGameTests/GameInputHandlerTests.cpp
+++ b/ConsoleGameTests/GameInputHandlerTests.cpp
@@ -3,9 +3,6 @@
 #include <memory>
 
 #include <ConsoleGame/GameInputHandler.h>
-#include <ConsoleGame/GameState.h>
-#include <ConsoleGame/GameButton.h>
-#include <ConsoleGame/GameEvent.h>
 
 #include "mock_GameInputReader.h"
 #include "mock_GameInfoProvider.h"

--- a/ConsoleGameTests/GameRendererTests.cpp
+++ b/ConsoleGameTests/GameRendererTests.cpp
@@ -59,7 +59,7 @@ protected:
    shared_ptr<GameRenderer> _renderer;
 };
 
-TEST_F( GameRendererTests, Constructor_Always_LoadsScreenBufferFromConfig )
+TEST_F( GameRendererTests, Constructor_Always_LoadsScreenBufferFromDefs )
 {
    auto baseDefs = static_pointer_cast<IGameRenderDefs>( _renderDefs );
    EXPECT_CALL( *_screenBufferMock, LoadRenderDefs( baseDefs ) );

--- a/ConsoleGameTests/GameRendererTests.cpp
+++ b/ConsoleGameTests/GameRendererTests.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include <ConsoleGame/GameRenderer.h>
-#include <ConsoleGame/ConsoleRenderConfig.h>
+#include <ConsoleGame/ConsoleRenderDefs.h>
 #include <ConsoleGame/IScreenBuffer.h>
 #include <ConsoleGame/IGameInfoProvider.h>
 #include <ConsoleGame/GameEventAggregator.h>
@@ -24,22 +24,22 @@ class GameRendererTests : public Test
 public:
    void SetUp() override
    {
-      _renderConfig.reset( new ConsoleRenderConfig );
+      _renderDefs.reset( new ConsoleRenderDefs );
       _screenBufferMock.reset( new NiceMock<mock_ScreenBuffer> );
       _gameInfoProviderMock.reset( new NiceMock<mock_GameInfoProvider> );
       _diagnosticsRendererMock.reset( new NiceMock<mock_GameRenderer> );
       _eventAggregator.reset( new GameEventAggregator );
       _startupStateRendererMock.reset( new NiceMock<mock_GameRenderer> );
 
-      _renderConfig->DefaultBackgroundColor = ConsoleColor::Black;
-      _renderConfig->DefaultForegroundColor = ConsoleColor::Grey;
+      _renderDefs->DefaultBackgroundColor = ConsoleColor::Black;
+      _renderDefs->DefaultForegroundColor = ConsoleColor::Grey;
 
       ON_CALL( *_gameInfoProviderMock, GetGameState() ).WillByDefault( Return( GameState::Startup ) );
    }
 
    void BuildRenderer()
    {
-      _renderer.reset( new GameRenderer( _renderConfig,
+      _renderer.reset( new GameRenderer( _renderDefs,
                                          _screenBufferMock,
                                          _gameInfoProviderMock,
                                          _diagnosticsRendererMock,
@@ -49,7 +49,7 @@ public:
    }
 
 protected:
-   shared_ptr<ConsoleRenderConfig> _renderConfig;
+   shared_ptr<ConsoleRenderDefs> _renderDefs;
    shared_ptr<mock_ScreenBuffer> _screenBufferMock;
    shared_ptr<mock_GameInfoProvider> _gameInfoProviderMock;
    shared_ptr<mock_GameRenderer> _diagnosticsRendererMock;
@@ -61,8 +61,8 @@ protected:
 
 TEST_F( GameRendererTests, Constructor_Always_LoadsScreenBufferFromConfig )
 {
-   auto baseConfig = static_pointer_cast<IGameRenderConfig>( _renderConfig );
-   EXPECT_CALL( *_screenBufferMock, LoadRenderConfig( baseConfig ) );
+   auto baseDefs = static_pointer_cast<IGameRenderDefs>( _renderDefs );
+   EXPECT_CALL( *_screenBufferMock, LoadRenderDefs( baseDefs ) );
 
    BuildRenderer();
 }

--- a/ConsoleGameTests/GameRendererTests.cpp
+++ b/ConsoleGameTests/GameRendererTests.cpp
@@ -7,9 +7,6 @@
 #include <ConsoleGame/IScreenBuffer.h>
 #include <ConsoleGame/IGameInfoProvider.h>
 #include <ConsoleGame/GameEventAggregator.h>
-#include <ConsoleGame/ConsoleColor.h>
-#include <ConsoleGame/GameState.h>
-#include <ConsoleGame/ConsoleSprite.h>
 
 #include "mock_ScreenBuffer.h"
 #include "mock_GameInfoProvider.h"

--- a/ConsoleGameTests/GameRunnerTests.cpp
+++ b/ConsoleGameTests/GameRunnerTests.cpp
@@ -5,7 +5,6 @@
 
 #include <ConsoleGame/GameRunner.h>
 #include <ConsoleGame/GameEventAggregator.h>
-#include <ConsoleGame/GameEvent.h>
 
 #include "mock_GameClock.h"
 #include "mock_GameInputHandler.h"

--- a/ConsoleGameTests/GameTests.cpp
+++ b/ConsoleGameTests/GameTests.cpp
@@ -5,7 +5,7 @@
 #include <ConsoleGame/Game.h>
 #include <ConsoleGame/GameConfig.h>
 #include <ConsoleGame/PlayerConfig.h>
-#include <ConsoleGame/ArenaConfig.h>
+#include <ConsoleGame/ArenaDefs.h>
 #include <ConsoleGame/GameState.h>
 #include <ConsoleGame/Direction.h>
 #include <ConsoleGame/GameCommand.h>
@@ -27,15 +27,15 @@ public:
    {
       _config.reset( new GameConfig );
       _config->PlayerConfig.reset( new PlayerConfig );
-      _config->ArenaConfig.reset( new ArenaConfig );
+      _config->ArenaDefs.reset( new ArenaDefs );
       _eventAggregatorMock.reset( new NiceMock<mock_GameEventAggregator> );
       _playerFactoryMock.reset( new NiceMock<mock_PlayerFactory> );
       _playerMock.reset( new NiceMock<mock_Player> );
 
-      _config->ArenaConfig->Width = 1000.;
-      _config->ArenaConfig->Height = 800.;
-      _config->ArenaConfig->PlayerStartX = 500.;
-      _config->ArenaConfig->PlayerStartY = 400.;
+      _config->ArenaDefs->Width = 1000.;
+      _config->ArenaDefs->Height = 800.;
+      _config->ArenaDefs->PlayerStartX = 500.;
+      _config->ArenaDefs->PlayerStartY = 400.;
 
       _config->FramesPerSecond = 100;
 
@@ -65,8 +65,8 @@ TEST_F( GameTests, Constructor_Always_SetsGameStateToStartup )
 
 TEST_F( GameTests, Constructor_Always_SetsPlayerInfoBasedOnConfig )
 {
-   _config->ArenaConfig->PlayerStartX = 10.;
-   _config->ArenaConfig->PlayerStartY = 20.;
+   _config->ArenaDefs->PlayerStartX = 10.;
+   _config->ArenaDefs->PlayerStartY = 20.;
 
    BuildGame();
 
@@ -142,7 +142,7 @@ TEST_F( GameTests, IsPlayerMoving_PlayerIsMovingVertically_ReturnsTrue )
 
 TEST_F( GameTests, GetArenaWidth_Always_GetsArenaWidthFromConfig )
 {
-   _config->ArenaConfig->Width = 11.;
+   _config->ArenaDefs->Width = 11.;
    BuildGame();
 
    EXPECT_EQ( _game->GetArenaWidth(), 11. );
@@ -150,7 +150,7 @@ TEST_F( GameTests, GetArenaWidth_Always_GetsArenaWidthFromConfig )
 
 TEST_F( GameTests, GetArenaHeight_Always_GetsArenaHeightFromConfig )
 {
-   _config->ArenaConfig->Height = 12.;
+   _config->ArenaDefs->Height = 12.;
    BuildGame();
 
    EXPECT_EQ( _game->GetArenaHeight(), 12. );

--- a/ConsoleGameTests/GameTests.cpp
+++ b/ConsoleGameTests/GameTests.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include <ConsoleGame/Game.h>
-#include <ConsoleGame/GameConfig.h>
+#include <ConsoleGame/GameDefs.h>
 #include <ConsoleGame/PlayerDefs.h>
 #include <ConsoleGame/ArenaDefs.h>
 #include <ConsoleGame/GameState.h>
@@ -25,30 +25,30 @@ class GameTests : public Test
 public:
    void SetUp() override
    {
-      _config.reset( new GameConfig );
-      _config->PlayerDefs.reset( new PlayerDefs );
-      _config->ArenaDefs.reset( new ArenaDefs );
+      _gameDefs.reset( new GameDefs );
+      _gameDefs->PlayerDefs.reset( new PlayerDefs );
+      _gameDefs->ArenaDefs.reset( new ArenaDefs );
       _eventAggregatorMock.reset( new NiceMock<mock_GameEventAggregator> );
       _playerFactoryMock.reset( new NiceMock<mock_PlayerFactory> );
       _playerMock.reset( new NiceMock<mock_Player> );
 
-      _config->ArenaDefs->Width = 1000.;
-      _config->ArenaDefs->Height = 800.;
-      _config->ArenaDefs->PlayerStartX = 500.;
-      _config->ArenaDefs->PlayerStartY = 400.;
+      _gameDefs->ArenaDefs->Width = 1000.;
+      _gameDefs->ArenaDefs->Height = 800.;
+      _gameDefs->ArenaDefs->PlayerStartX = 500.;
+      _gameDefs->ArenaDefs->PlayerStartY = 400.;
 
-      _config->FramesPerSecond = 100;
+      _gameDefs->FramesPerSecond = 100;
 
       ON_CALL( *_playerFactoryMock, CreatePlayer() ).WillByDefault( Return( _playerMock ) );
    }
 
    void BuildGame()
    {
-      _game.reset( new Game( _config, _eventAggregatorMock, _playerFactoryMock ) );
+      _game.reset( new Game( _gameDefs, _eventAggregatorMock, _playerFactoryMock ) );
    }
 
 protected:
-   shared_ptr<GameConfig> _config;
+   shared_ptr<GameDefs> _gameDefs;
    shared_ptr<mock_GameEventAggregator> _eventAggregatorMock;
    shared_ptr<mock_PlayerFactory> _playerFactoryMock;
    shared_ptr<mock_Player> _playerMock;
@@ -63,10 +63,10 @@ TEST_F( GameTests, Constructor_Always_SetsGameStateToStartup )
    EXPECT_EQ( _game->GetGameState(), GameState::Startup );
 }
 
-TEST_F( GameTests, Constructor_Always_SetsPlayerInfoBasedOnConfig )
+TEST_F( GameTests, Constructor_Always_SetsPlayerInfoBasedOnDefs )
 {
-   _config->ArenaDefs->PlayerStartX = 10.;
-   _config->ArenaDefs->PlayerStartY = 20.;
+   _gameDefs->ArenaDefs->PlayerStartX = 10.;
+   _gameDefs->ArenaDefs->PlayerStartY = 20.;
 
    BuildGame();
 
@@ -140,17 +140,17 @@ TEST_F( GameTests, IsPlayerMoving_PlayerIsMovingVertically_ReturnsTrue )
    EXPECT_TRUE( _game->IsPlayerMoving() );
 }
 
-TEST_F( GameTests, GetArenaWidth_Always_GetsArenaWidthFromConfig )
+TEST_F( GameTests, GetArenaWidth_Always_GetsArenaWidthFromDefs )
 {
-   _config->ArenaDefs->Width = 11.;
+   _gameDefs->ArenaDefs->Width = 11.;
    BuildGame();
 
    EXPECT_EQ( _game->GetArenaWidth(), 11. );
 }
 
-TEST_F( GameTests, GetArenaHeight_Always_GetsArenaHeightFromConfig )
+TEST_F( GameTests, GetArenaHeight_Always_GetsArenaHeightFromDefs )
 {
-   _config->ArenaDefs->Height = 12.;
+   _gameDefs->ArenaDefs->Height = 12.;
    BuildGame();
 
    EXPECT_EQ( _game->GetArenaHeight(), 12. );

--- a/ConsoleGameTests/GameTests.cpp
+++ b/ConsoleGameTests/GameTests.cpp
@@ -4,7 +4,7 @@
 
 #include <ConsoleGame/Game.h>
 #include <ConsoleGame/GameConfig.h>
-#include <ConsoleGame/PlayerConfig.h>
+#include <ConsoleGame/PlayerDefs.h>
 #include <ConsoleGame/ArenaDefs.h>
 #include <ConsoleGame/GameState.h>
 #include <ConsoleGame/Direction.h>
@@ -26,7 +26,7 @@ public:
    void SetUp() override
    {
       _config.reset( new GameConfig );
-      _config->PlayerConfig.reset( new PlayerConfig );
+      _config->PlayerDefs.reset( new PlayerDefs );
       _config->ArenaDefs.reset( new ArenaDefs );
       _eventAggregatorMock.reset( new NiceMock<mock_GameEventAggregator> );
       _playerFactoryMock.reset( new NiceMock<mock_PlayerFactory> );

--- a/ConsoleGameTests/GameTests.cpp
+++ b/ConsoleGameTests/GameTests.cpp
@@ -6,10 +6,6 @@
 #include <ConsoleGame/GameDefs.h>
 #include <ConsoleGame/PlayerDefs.h>
 #include <ConsoleGame/ArenaDefs.h>
-#include <ConsoleGame/GameState.h>
-#include <ConsoleGame/Direction.h>
-#include <ConsoleGame/GameCommand.h>
-#include <ConsoleGame/GameEvent.h>
 #include <ConsoleGame/PushPlayerCommandArgs.h>
 
 #include "mock_GameEventAggregator.h"

--- a/ConsoleGameTests/KeyboardInputReaderTests.cpp
+++ b/ConsoleGameTests/KeyboardInputReaderTests.cpp
@@ -4,8 +4,6 @@
 
 #include <ConsoleGame/KeyboardInputReader.h>
 #include <ConsoleGame/KeyboardInputDefs.h>
-#include <ConsoleGame/KeyCode.h>
-#include <ConsoleGame/GameButton.h>
 
 #include "mock_Keyboard.h"
 

--- a/ConsoleGameTests/KeyboardInputReaderTests.cpp
+++ b/ConsoleGameTests/KeyboardInputReaderTests.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include <ConsoleGame/KeyboardInputReader.h>
-#include <ConsoleGame/KeyboardInputConfig.h>
+#include <ConsoleGame/KeyboardInputDefs.h>
 #include <ConsoleGame/KeyCode.h>
 #include <ConsoleGame/GameButton.h>
 
@@ -18,23 +18,23 @@ class KeyboardInputReaderTests : public Test
 public:
    void SetUp() override
    {
-      _inputConfig.reset( new KeyboardInputConfig );
+      _inputDefs.reset( new KeyboardInputDefs );
       _keyboardMock.reset( new NiceMock<mock_Keyboard> );
    }
 
    void AddKeyBinding( KeyCode keyCode, GameButton gameButton )
    {
-      _inputConfig->KeyMap[keyCode] = gameButton;
+      _inputDefs->KeyMap[keyCode] = gameButton;
    }
 
    void BuildInputReader()
    {
-      _inputReader.reset( new KeyboardInputReader( _inputConfig,
+      _inputReader.reset( new KeyboardInputReader( _inputDefs,
                                                    _keyboardMock ) );
    }
 
 protected:
-   shared_ptr<KeyboardInputConfig> _inputConfig;
+   shared_ptr<KeyboardInputDefs> _inputDefs;
    shared_ptr<mock_Keyboard> _keyboardMock;
 
    shared_ptr<KeyboardInputReader> _inputReader;

--- a/ConsoleGameTests/PlayerTests.cpp
+++ b/ConsoleGameTests/PlayerTests.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include <ConsoleGame/Player.h>
-#include <ConsoleGame/PlayerConfig.h>
+#include <ConsoleGame/PlayerDefs.h>
 
 using namespace std;
 using namespace testing;
@@ -14,34 +14,34 @@ class PlayerTests : public Test
 public:
    void SetUp() override
    {
-      _config.reset( new PlayerConfig );
+      _playerDefs.reset( new PlayerDefs );
 
-      _config->StartVelocityX = 0.;
-      _config->StartVelocityY = 0.;
-      _config->MaxVelocity = 100.;
-      _config->AccelerationPerSecond = 200.;
-      _config->StartDirection = Direction::Left;
+      _playerDefs->StartVelocityX = 0.;
+      _playerDefs->StartVelocityY = 0.;
+      _playerDefs->MaxVelocity = 100.;
+      _playerDefs->AccelerationPerSecond = 200.;
+      _playerDefs->StartDirection = Direction::Left;
 
       _framesPerSecond = 100;
    }
 
    void BuildPlayer()
    {
-      _player.reset( new Player( _config, _framesPerSecond ) );
+      _player.reset( new Player( _playerDefs, _framesPerSecond ) );
    }
 
 protected:
-   shared_ptr<PlayerConfig> _config;
+   shared_ptr<PlayerDefs> _playerDefs;
    int _framesPerSecond;
 
    shared_ptr<Player> _player;
 };
 
-TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromConfig )
+TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromDefs )
 {
-   _config->StartVelocityX = 100.;
-   _config->StartVelocityY = 200.;
-   _config->StartDirection = Direction::Right;
+   _playerDefs->StartVelocityX = 100.;
+   _playerDefs->StartVelocityY = 200.;
+   _playerDefs->StartDirection = Direction::Right;
    BuildPlayer();
 
    EXPECT_EQ( _player->GetVelocityX(), 100. );
@@ -51,7 +51,7 @@ TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromConfig )
 
 TEST_F( PlayerTests, Push_Always_SetsDirection )
 {
-   _config->StartDirection = Direction::Right;
+   _playerDefs->StartDirection = Direction::Right;
    BuildPlayer();
 
    _player->Push( Direction::Up );
@@ -137,7 +137,7 @@ TEST_F( PlayerTests, Push_DownLeftAndVelocityHasNotMaxedOut_DecreasesXVelocityAn
 
 TEST_F( PlayerTests, Push_LeftAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _config->AccelerationPerSecond = 100001.;
+   _playerDefs->AccelerationPerSecond = 100001.;
    BuildPlayer();
 
    _player->Push( Direction::Left );
@@ -147,7 +147,7 @@ TEST_F( PlayerTests, Push_LeftAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 
 TEST_F( PlayerTests, Push_RightAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _config->AccelerationPerSecond = 100001.;
+   _playerDefs->AccelerationPerSecond = 100001.;
    BuildPlayer();
 
    _player->Push( Direction::Right );
@@ -157,7 +157,7 @@ TEST_F( PlayerTests, Push_RightAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 
 TEST_F( PlayerTests, Push_UpAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _config->AccelerationPerSecond = 10001.;
+   _playerDefs->AccelerationPerSecond = 10001.;
    BuildPlayer();
 
    _player->Push( Direction::Up );
@@ -167,7 +167,7 @@ TEST_F( PlayerTests, Push_UpAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 
 TEST_F( PlayerTests, Push_DownAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _config->AccelerationPerSecond = 10001.;
+   _playerDefs->AccelerationPerSecond = 10001.;
    BuildPlayer();
 
    _player->Push( Direction::Down );
@@ -221,8 +221,8 @@ TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingDownAndHasVelocityToSpare_Does
 
 TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingLeftAndHasNoVelocityToSpare_Stops )
 {
-   _config->StartVelocityX = -1.;
-   _config->MaxVelocity = 2.;
+   _playerDefs->StartVelocityX = -1.;
+   _playerDefs->MaxVelocity = 2.;
    BuildPlayer();
 
    _player->ApplyFrictionX();
@@ -232,8 +232,8 @@ TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingLeftAndHasNoVelocityToSpare_St
 
 TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingRightAndHasNoVelocityToSpare_Stops )
 {
-   _config->StartVelocityX = 1.;
-   _config->MaxVelocity = 2.;
+   _playerDefs->StartVelocityX = 1.;
+   _playerDefs->MaxVelocity = 2.;
    BuildPlayer();
 
    _player->ApplyFrictionX();
@@ -243,8 +243,8 @@ TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingRightAndHasNoVelocityToSpare_S
 
 TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingUpAndHasNoVelocityToSpare_Stops )
 {
-   _config->StartVelocityY = -1.;
-   _config->MaxVelocity = 2.;
+   _playerDefs->StartVelocityY = -1.;
+   _playerDefs->MaxVelocity = 2.;
    BuildPlayer();
 
    _player->ApplyFrictionY();
@@ -254,8 +254,8 @@ TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingUpAndHasNoVelocityToSpare_Stop
 
 TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingDownAndHasNoVelocityToSpare_Stops )
 {
-   _config->StartVelocityY = 1.;
-   _config->MaxVelocity = 2.;
+   _playerDefs->StartVelocityY = 1.;
+   _playerDefs->MaxVelocity = 2.;
    BuildPlayer();
 
    _player->ApplyFrictionY();

--- a/ConsoleGameTests/PlayingStateInputHandlerTests.cpp
+++ b/ConsoleGameTests/PlayingStateInputHandlerTests.cpp
@@ -3,10 +3,7 @@
 #include <memory>
 
 #include <ConsoleGame/PlayingStateInputHandler.h>
-#include <ConsoleGame/GameButton.h>
-#include <ConsoleGame/GameCommand.h>
 #include <ConsoleGame/PushPlayerCommandArgs.h>
-#include <ConsoleGame/Direction.h>
 
 #include "mock_GameInputReader.h"
 #include "mock_GameCommandExecutor.h"

--- a/ConsoleGameTests/StartupStateInputHandlerTests.cpp
+++ b/ConsoleGameTests/StartupStateInputHandlerTests.cpp
@@ -3,8 +3,6 @@
 #include <memory>
 
 #include <ConsoleGame/StartupStateInputHandler.h>
-#include <ConsoleGame/GameButton.h>
-#include <ConsoleGame/GameCommand.h>
 #include <ConsoleGame/GameCommandArgs.h>
 
 #include "mock_GameInputReader.h"

--- a/ConsoleGameTests/mock_ConsoleBuffer.h
+++ b/ConsoleGameTests/mock_ConsoleBuffer.h
@@ -7,7 +7,7 @@
 class mock_ConsoleBuffer : public ConsoleGame::IConsoleBuffer
 {
 public:
-   MOCK_METHOD( void, Initialize, ( ), ( override ) );
+   MOCK_METHOD( void, LoadRenderDefs, ( std::shared_ptr<ConsoleGame::IGameRenderDefs> ), ( override ) );
    MOCK_METHOD( void, CleanUp, ( ), ( override ) );
 
    MOCK_METHOD( void, SetDefaultForegroundColor, ( ConsoleGame::ConsoleColor ), ( override ) );

--- a/ConsoleGameTests/mock_GameClock.h
+++ b/ConsoleGameTests/mock_GameClock.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <gmock/gmock.h>
-#include <string>
 
 #include <ConsoleGame/IGameClock.h>
 

--- a/ConsoleGameTests/mock_ScreenBuffer.h
+++ b/ConsoleGameTests/mock_ScreenBuffer.h
@@ -7,7 +7,7 @@
 class mock_ScreenBuffer : public ConsoleGame::IScreenBuffer
 {
 public:
-   MOCK_METHOD( void, LoadRenderConfig, ( const std::shared_ptr<ConsoleGame::IGameRenderConfig> ), ( override ) );
+   MOCK_METHOD( void, LoadRenderDefs, ( const std::shared_ptr<ConsoleGame::IGameRenderDefs> ), ( override ) );
    MOCK_METHOD( void, CleanUp, ( ), ( override ) );
    MOCK_METHOD( void, Clear, ( ), ( override ) );
    MOCK_METHOD( void, Flip, ( ), ( override ) );


### PR DESCRIPTION
After using this repo to make a real project, one of the lessons I learned is that the `Config` objects are more like `Defs`. I like to think of a "config" as something the user can change through a menu or the registry or something, but there's a lot of stuff in these classes that the user should never touch. So now we have these objects:

- ArenaDefs
- ConsoleRenderDefs
- GameDefs
- KeyboardInputDefs
- PlayerDefs

**BONUS**

It was bugging me, so I went through and rearranged a bunch of `#include`s and forward-declarations to make things simpler. Now there are no `enum class` or `struct` forward declarations (with the exception of one, in `ConsoleBuffer.h`, which is only there so I don't have to do an `#include <Windows.h>` in the header), I just include the associated header directly in the file. As a result, a whole bunch of other `#include`s could be removed from a ton of files, it's cleaner. Regular `class`es should still always be forward-declared though.