### PR TITLE
Use floats instead of doubles for arena units

### DIFF
--- a/ConsoleGame/ArenaDefs.h
+++ b/ConsoleGame/ArenaDefs.h
@@ -5,10 +5,10 @@ namespace ConsoleGame
    class ArenaDefs
    {
    public:
-      double Width = 0.;
-      double Height = 0.;
+      float Width = 0;
+      float Height = 0;
 
-      double PlayerStartX = 0.;
-      double PlayerStartY = 0.;
+      float PlayerStartX = 0;
+      float PlayerStartY = 0;
    };
 }

--- a/ConsoleGame/ConsoleGame.cpp
+++ b/ConsoleGame/ConsoleGame.cpp
@@ -253,16 +253,16 @@ shared_ptr<PlayerDefs> BuildPlayerDefs()
 {
    auto playerDefs = make_shared<PlayerDefs>();
 
-   playerDefs->StartVelocityX = 0.;
-   playerDefs->StartVelocityY = 0.;
+   playerDefs->StartVelocityX = 0;
+   playerDefs->StartVelocityY = 0;
 
    // this means at max velocity, it should take
    // 3 seconds to cross the arena horizontally
-   playerDefs->MaxVelocity = 1444.;
+   playerDefs->MaxVelocity = 1444;
 
    // this means it should take a third of a second
    // to go from 0 to max velocity
-   playerDefs->AccelerationPerSecond = 4332.;
+   playerDefs->AccelerationPerSecond = 4332;
 
    playerDefs->StartDirection = Direction::Right;
 
@@ -273,11 +273,11 @@ shared_ptr<ArenaDefs> BuildArenaDefs()
 {
    auto arenaDefs = make_shared<ArenaDefs>();
 
-   arenaDefs->Width = 4332.;
-   arenaDefs->Height = 1872.;
+   arenaDefs->Width = 4332;
+   arenaDefs->Height = 1872;
 
-   arenaDefs->PlayerStartX = arenaDefs->Width / 2.;
-   arenaDefs->PlayerStartY = arenaDefs->Height / 2.;
+   arenaDefs->PlayerStartX = arenaDefs->Width / 2.0f;
+   arenaDefs->PlayerStartY = arenaDefs->Height / 2.0f;
 
    return arenaDefs;
 }

--- a/ConsoleGame/Game.cpp
+++ b/ConsoleGame/Game.cpp
@@ -72,15 +72,15 @@ Direction Game::GetPlayerDirection() const
 
 bool Game::IsPlayerMoving() const
 {
-   return _player->GetVelocityX() != 0. || _player->GetVelocityY() != 0.;
+   return _player->GetVelocityX() != 0 || _player->GetVelocityY() != 0;
 }
 
-double Game::GetArenaWidth() const
+float Game::GetArenaWidth() const
 {
    return _gameDefs->ArenaDefs->Width;
 }
 
-double Game::GetArenaHeight() const
+float Game::GetArenaHeight() const
 {
    return _gameDefs->ArenaDefs->Height;
 }
@@ -103,27 +103,27 @@ void Game::MovePlayer()
 {
    _arenaPlayerPositionX += ( _player->GetVelocityX() / _gameDefs->FramesPerSecond );
 
-   if ( _arenaPlayerPositionX < 0. )
+   if ( _arenaPlayerPositionX < 0 )
    {
-      _arenaPlayerPositionX = 0.;
+      _arenaPlayerPositionX = 0;
       _player->StopX();
    }
    else if ( _arenaPlayerPositionX >= _gameDefs->ArenaDefs->Width )
    {
-      _arenaPlayerPositionX = _gameDefs->ArenaDefs->Width - 1.;
+      _arenaPlayerPositionX = _gameDefs->ArenaDefs->Width - 1;
       _player->StopX();
    }
 
    _arenaPlayerPositionY += ( _player->GetVelocityY() / _gameDefs->FramesPerSecond );
 
-   if ( _arenaPlayerPositionY < 0. )
+   if ( _arenaPlayerPositionY < 0 )
    {
-      _arenaPlayerPositionY = 0.;
+      _arenaPlayerPositionY = 0;
       _player->StopY();
    }
    else if ( _arenaPlayerPositionY >= _gameDefs->ArenaDefs->Height )
    {
-      _arenaPlayerPositionY = _gameDefs->ArenaDefs->Height - 1.;
+      _arenaPlayerPositionY = _gameDefs->ArenaDefs->Height - 1;
       _player->StopY();
    }
 }

--- a/ConsoleGame/Game.h
+++ b/ConsoleGame/Game.h
@@ -30,11 +30,11 @@ namespace ConsoleGame
       Direction GetPlayerDirection() const override;
       bool IsPlayerMoving() const override;
 
-      double GetArenaWidth() const override;
-      double GetArenaHeight() const override;
+      float GetArenaWidth() const override;
+      float GetArenaHeight() const override;
 
-      double GetArenaPlayerXPosition() const override { return _arenaPlayerPositionX; }
-      double GetArenaPlayerYPosition() const override { return _arenaPlayerPositionY; }
+      float GetArenaPlayerXPosition() const override { return _arenaPlayerPositionX; }
+      float GetArenaPlayerYPosition() const override { return _arenaPlayerPositionY; }
 
    private:
       void PushPlayer( Direction direction );
@@ -47,8 +47,8 @@ namespace ConsoleGame
 
       GameState _state;
 
-      double _arenaPlayerPositionX;
-      double _arenaPlayerPositionY;
+      float _arenaPlayerPositionX;
+      float _arenaPlayerPositionY;
 
       bool _playerWasPushedX;
       bool _playerWasPushedY;

--- a/ConsoleGame/IGameInfoProvider.h
+++ b/ConsoleGame/IGameInfoProvider.h
@@ -13,10 +13,10 @@ namespace ConsoleGame
       virtual Direction GetPlayerDirection() const = 0;
       virtual bool IsPlayerMoving() const = 0;
 
-      virtual double GetArenaWidth() const = 0;
-      virtual double GetArenaHeight() const = 0;
+      virtual float GetArenaWidth() const = 0;
+      virtual float GetArenaHeight() const = 0;
 
-      virtual double GetArenaPlayerXPosition() const = 0;
-      virtual double GetArenaPlayerYPosition() const = 0;
+      virtual float GetArenaPlayerXPosition() const = 0;
+      virtual float GetArenaPlayerYPosition() const = 0;
    };
 }

--- a/ConsoleGame/IPlayer.h
+++ b/ConsoleGame/IPlayer.h
@@ -13,8 +13,8 @@ namespace ConsoleGame
       virtual void StopX() = 0;
       virtual void StopY() = 0;
 
-      virtual double GetVelocityX() const = 0;
-      virtual double GetVelocityY() const = 0;
+      virtual float GetVelocityX() const = 0;
+      virtual float GetVelocityY() const = 0;
 
       virtual Direction GetDirection() const = 0;
    };

--- a/ConsoleGame/Player.cpp
+++ b/ConsoleGame/Player.cpp
@@ -57,36 +57,36 @@ void Player::Push( Direction direction )
 
 void Player::ApplyFrictionX()
 {
-   if ( _velocityX < 0. )
+   if ( _velocityX < 0 )
    {
-      _velocityX = min( _velocityX + _velocityDelta, 0. );
+      _velocityX = min( _velocityX + _velocityDelta, 0.0f );
    }
-   else if ( _velocityX > 0. )
+   else if ( _velocityX > 0 )
    {
-      _velocityX = max( _velocityX - _velocityDelta, 0. );
+      _velocityX = max( _velocityX - _velocityDelta, 0.0f );
    }
 }
 
 void Player::ApplyFrictionY()
 {
-   if ( _velocityY < 0. )
+   if ( _velocityY < 0 )
    {
-      _velocityY = min( _velocityY + _velocityDelta, 0. );
+      _velocityY = min( _velocityY + _velocityDelta, 0.0f );
    }
-   else if ( _velocityY > 0. )
+   else if ( _velocityY > 0 )
    {
-      _velocityY = max( _velocityY - _velocityDelta, 0. );
+      _velocityY = max( _velocityY - _velocityDelta, 0.0f );
    }
 }
 
 void Player::StopX()
 {
-   _velocityX = 0.;
+   _velocityX = 0;
 }
 
 void Player::StopY()
 {
-   _velocityY = 0.;
+   _velocityY = 0;
 }
 
 void Player::ClampVelocity()

--- a/ConsoleGame/Player.h
+++ b/ConsoleGame/Player.h
@@ -20,8 +20,8 @@ namespace ConsoleGame
       void StopX() override;
       void StopY() override;
 
-      double GetVelocityX() const override { return _velocityX; }
-      double GetVelocityY() const override { return _velocityY; }
+      float GetVelocityX() const override { return _velocityX; }
+      float GetVelocityY() const override { return _velocityY; }
 
       Direction GetDirection() const override { return _direction; }
 
@@ -31,10 +31,10 @@ namespace ConsoleGame
    private:
       const std::shared_ptr<PlayerDefs> _playerDefs;
 
-      double _velocityX;
-      double _velocityY;
+      float _velocityX;
+      float _velocityY;
 
-      double _velocityDelta;
+      float _velocityDelta;
 
       Direction _direction;
    };

--- a/ConsoleGame/PlayerDefs.h
+++ b/ConsoleGame/PlayerDefs.h
@@ -7,12 +7,12 @@ namespace ConsoleGame
    class PlayerDefs
    {
    public:
-      double StartVelocityX = 0.;
-      double StartVelocityY = 0.;
+      float StartVelocityX = 0;
+      float StartVelocityY = 0;
 
-      double MaxVelocity = 0.;
+      float MaxVelocity = 0;
 
-      double AccelerationPerSecond = 0.;
+      float AccelerationPerSecond = 0;
 
       Direction StartDirection = (Direction)0;
    };

--- a/ConsoleGame/PlayingStateConsoleRenderer.h
+++ b/ConsoleGame/PlayingStateConsoleRenderer.h
@@ -28,7 +28,7 @@ namespace ConsoleGame
       const std::shared_ptr<ConsoleRenderDefs> _renderDefs;
       const std::shared_ptr<IGameInfoProvider> _gameInfoProvider;
 
-      double _arenaCoordConverterX;
-      double _arenaCoordConverterY;
+      float _arenaCoordConverterX;
+      float _arenaCoordConverterY;
    };
 }

--- a/ConsoleGameTests/GameTests.cpp
+++ b/ConsoleGameTests/GameTests.cpp
@@ -28,10 +28,10 @@ public:
       _playerFactoryMock.reset( new NiceMock<mock_PlayerFactory> );
       _playerMock.reset( new NiceMock<mock_Player> );
 
-      _gameDefs->ArenaDefs->Width = 1000.;
-      _gameDefs->ArenaDefs->Height = 800.;
-      _gameDefs->ArenaDefs->PlayerStartX = 500.;
-      _gameDefs->ArenaDefs->PlayerStartY = 400.;
+      _gameDefs->ArenaDefs->Width = 1000;
+      _gameDefs->ArenaDefs->Height = 800;
+      _gameDefs->ArenaDefs->PlayerStartX = 500;
+      _gameDefs->ArenaDefs->PlayerStartY = 400;
 
       _gameDefs->FramesPerSecond = 100;
 
@@ -61,13 +61,13 @@ TEST_F( GameTests, Constructor_Always_SetsGameStateToStartup )
 
 TEST_F( GameTests, Constructor_Always_SetsPlayerInfoBasedOnDefs )
 {
-   _gameDefs->ArenaDefs->PlayerStartX = 10.;
-   _gameDefs->ArenaDefs->PlayerStartY = 20.;
+   _gameDefs->ArenaDefs->PlayerStartX = 10;
+   _gameDefs->ArenaDefs->PlayerStartY = 20;
 
    BuildGame();
 
-   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 10. );
-   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 20. );
+   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 10 );
+   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 20 );
 }
 
 TEST_F( GameTests, ExecuteCommand_Start_SetsGameStateToPlaying )
@@ -109,8 +109,8 @@ TEST_F( GameTests, GetPlayerDirection_Always_GetsDirectionFromPlayer )
 
 TEST_F( GameTests, IsPlayerMoving_PlayerIsNotMoving_ReturnsFalse )
 {
-   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( 0. ) );
-   EXPECT_CALL( *_playerMock, GetVelocityY() ).WillOnce( Return( 0. ) );
+   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( 0.0f ) );
+   EXPECT_CALL( *_playerMock, GetVelocityY() ).WillOnce( Return( 0.0f ) );
 
    BuildGame();
 
@@ -119,7 +119,7 @@ TEST_F( GameTests, IsPlayerMoving_PlayerIsNotMoving_ReturnsFalse )
 
 TEST_F( GameTests, IsPlayerMoving_PlayerIsMovingHorizontally_ReturnsTrue )
 {
-   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( -1. ) );
+   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( -1.0f ) );
 
    BuildGame();
 
@@ -128,8 +128,8 @@ TEST_F( GameTests, IsPlayerMoving_PlayerIsMovingHorizontally_ReturnsTrue )
 
 TEST_F( GameTests, IsPlayerMoving_PlayerIsMovingVertically_ReturnsTrue )
 {
-   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( 0. ) );
-   EXPECT_CALL( *_playerMock, GetVelocityY() ).WillOnce( Return( 3. ) );
+   EXPECT_CALL( *_playerMock, GetVelocityX() ).WillOnce( Return( 0.0f ) );
+   EXPECT_CALL( *_playerMock, GetVelocityY() ).WillOnce( Return( 3.0f ) );
 
    BuildGame();
 
@@ -138,18 +138,18 @@ TEST_F( GameTests, IsPlayerMoving_PlayerIsMovingVertically_ReturnsTrue )
 
 TEST_F( GameTests, GetArenaWidth_Always_GetsArenaWidthFromDefs )
 {
-   _gameDefs->ArenaDefs->Width = 11.;
+   _gameDefs->ArenaDefs->Width = 11;
    BuildGame();
 
-   EXPECT_EQ( _game->GetArenaWidth(), 11. );
+   EXPECT_EQ( _game->GetArenaWidth(), 11 );
 }
 
 TEST_F( GameTests, GetArenaHeight_Always_GetsArenaHeightFromDefs )
 {
-   _gameDefs->ArenaDefs->Height = 12.;
+   _gameDefs->ArenaDefs->Height = 12;
    BuildGame();
 
-   EXPECT_EQ( _game->GetArenaHeight(), 12. );
+   EXPECT_EQ( _game->GetArenaHeight(), 12 );
 }
 
 TEST_F( GameTests, RunFrame_GameStateIsNotPlaying_DoesNotChangePlayerInfo )
@@ -194,51 +194,51 @@ TEST_F( GameTests, RunFrame_PlayerWasPushedVertically_DoesNotApplyYFriction )
 
 TEST_F( GameTests, RunFrame_PlayerIsMovingLeft_PlayerGetsMovedLeft )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -200. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -200.0f ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 498. );
+   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 498 );
 }
 
 TEST_F( GameTests, RunFrame_PlayerIsMovingRight_PlayerGetsMovedRight )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 200. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 200.0f ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 502. );
+   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 502 );
 }
 
 TEST_F( GameTests, RunFrame_PlayerIsMovingUp_PlayerGetsMovedUp )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -200. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -200.0f ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 398. );
+   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 398 );
 }
 
 TEST_F( GameTests, RunFrame_PlayerIsMovingDown_PlayerGetsMovedDown )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 200. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 200.0f ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 402. );
+   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 402 );
 }
 
 TEST_F( GameTests, RunFrame_PlayerHitsLeftWall_PlayerIsStoppedHorizontally )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -70001. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( -70001.0f ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
@@ -246,12 +246,12 @@ TEST_F( GameTests, RunFrame_PlayerHitsLeftWall_PlayerIsStoppedHorizontally )
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 0. );
+   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 0 );
 }
 
 TEST_F( GameTests, RunFrame_PlayerHitsRightWall_PlayerIsStoppedHorizontally )
 {
-   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 50001. ) );
+   ON_CALL( *_playerMock, GetVelocityX() ).WillByDefault( Return( 50001.0f ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
@@ -259,12 +259,12 @@ TEST_F( GameTests, RunFrame_PlayerHitsRightWall_PlayerIsStoppedHorizontally )
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 999. );
+   EXPECT_EQ( _game->GetArenaPlayerXPosition(), 999 );
 }
 
 TEST_F( GameTests, RunFrame_PlayerHitsTopWall_PlayerIsStoppedVertically )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -40001. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( -40001.0f ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
@@ -272,12 +272,12 @@ TEST_F( GameTests, RunFrame_PlayerHitsTopWall_PlayerIsStoppedVertically )
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 0. );
+   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 0 );
 }
 
 TEST_F( GameTests, RunFrame_PlayerHitsBottomWall_PlayerIsStoppedVertically )
 {
-   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 40001. ) );
+   ON_CALL( *_playerMock, GetVelocityY() ).WillByDefault( Return( 40001.0f ) );
    BuildGame();
    _game->ExecuteCommand( GameCommand::Start );
 
@@ -285,5 +285,5 @@ TEST_F( GameTests, RunFrame_PlayerHitsBottomWall_PlayerIsStoppedVertically )
 
    _game->RunFrame();
 
-   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 799. );
+   EXPECT_EQ( _game->GetArenaPlayerYPosition(), 799 );
 }

--- a/ConsoleGameTests/Mock_GameInfoProvider.h
+++ b/ConsoleGameTests/Mock_GameInfoProvider.h
@@ -10,8 +10,8 @@ public:
    MOCK_METHOD( ConsoleGame::GameState, GetGameState, ( ), ( const, override ) );
    MOCK_METHOD( ConsoleGame::Direction, GetPlayerDirection, ( ), ( const, override ) );
    MOCK_METHOD( bool, IsPlayerMoving, ( ), ( const, override ) );
-   MOCK_METHOD( double, GetArenaWidth, ( ), ( const, override ) );
-   MOCK_METHOD( double, GetArenaHeight, ( ), ( const, override ) );
-   MOCK_METHOD( double, GetArenaPlayerXPosition, ( ), ( const, override ) );
-   MOCK_METHOD( double, GetArenaPlayerYPosition, ( ), ( const, override ) );
+   MOCK_METHOD( float, GetArenaWidth, ( ), ( const, override ) );
+   MOCK_METHOD( float, GetArenaHeight, ( ), ( const, override ) );
+   MOCK_METHOD( float, GetArenaPlayerXPosition, ( ), ( const, override ) );
+   MOCK_METHOD( float, GetArenaPlayerYPosition, ( ), ( const, override ) );
 };

--- a/ConsoleGameTests/PlayerTests.cpp
+++ b/ConsoleGameTests/PlayerTests.cpp
@@ -16,10 +16,10 @@ public:
    {
       _playerDefs.reset( new PlayerDefs );
 
-      _playerDefs->StartVelocityX = 0.;
-      _playerDefs->StartVelocityY = 0.;
-      _playerDefs->MaxVelocity = 100.;
-      _playerDefs->AccelerationPerSecond = 200.;
+      _playerDefs->StartVelocityX = 0;
+      _playerDefs->StartVelocityY = 0;
+      _playerDefs->MaxVelocity = 100;
+      _playerDefs->AccelerationPerSecond = 200;
       _playerDefs->StartDirection = Direction::Left;
 
       _framesPerSecond = 100;
@@ -39,13 +39,13 @@ protected:
 
 TEST_F( PlayerTests, Constructor_Always_SetsDefaultPropertiesFromDefs )
 {
-   _playerDefs->StartVelocityX = 100.;
-   _playerDefs->StartVelocityY = 200.;
+   _playerDefs->StartVelocityX = 100;
+   _playerDefs->StartVelocityY = 200;
    _playerDefs->StartDirection = Direction::Right;
    BuildPlayer();
 
-   EXPECT_EQ( _player->GetVelocityX(), 100. );
-   EXPECT_EQ( _player->GetVelocityY(), 200. );
+   EXPECT_EQ( _player->GetVelocityX(), 100 );
+   EXPECT_EQ( _player->GetVelocityY(), 200 );
    EXPECT_EQ( _player->GetDirection(), Direction::Right );
 }
 
@@ -65,7 +65,7 @@ TEST_F( PlayerTests, Push_LeftAndVelocityHasNotMaxedOut_DecreasesXVelocity )
 
    _player->Push( Direction::Left );
 
-   EXPECT_EQ( _player->GetVelocityX(), -2. );
+   EXPECT_EQ( _player->GetVelocityX(), -2 );
 }
 
 TEST_F( PlayerTests, Push_UpLeftAndVelocityHasNotMaxedOut_DecreasesXAndYVelocity )
@@ -74,8 +74,8 @@ TEST_F( PlayerTests, Push_UpLeftAndVelocityHasNotMaxedOut_DecreasesXAndYVelocity
 
    _player->Push( Direction::UpLeft );
 
-   EXPECT_EQ( _player->GetVelocityX(), -2. );
-   EXPECT_EQ( _player->GetVelocityY(), -2. );
+   EXPECT_EQ( _player->GetVelocityX(), -2 );
+   EXPECT_EQ( _player->GetVelocityY(), -2 );
 }
 
 TEST_F( PlayerTests, Push_UpAndVelocityHasNotMaxedOut_DecreasesYVelocity )
@@ -84,7 +84,7 @@ TEST_F( PlayerTests, Push_UpAndVelocityHasNotMaxedOut_DecreasesYVelocity )
 
    _player->Push( Direction::Up );
 
-   EXPECT_EQ( _player->GetVelocityY(), -2. );
+   EXPECT_EQ( _player->GetVelocityY(), -2 );
 }
 
 TEST_F( PlayerTests, Push_UpRightAndVelocityHasNotMaxedOut_IncreasesXVelocityAndDecreasesYVelocity )
@@ -93,8 +93,8 @@ TEST_F( PlayerTests, Push_UpRightAndVelocityHasNotMaxedOut_IncreasesXVelocityAnd
 
    _player->Push( Direction::UpRight );
 
-   EXPECT_EQ( _player->GetVelocityX(), 2. );
-   EXPECT_EQ( _player->GetVelocityY(), -2. );
+   EXPECT_EQ( _player->GetVelocityX(), 2 );
+   EXPECT_EQ( _player->GetVelocityY(), -2 );
 }
 
 TEST_F( PlayerTests, Push_RightAndVelocityHasNotMaxedOut_IncreasesXVelocity )
@@ -103,7 +103,7 @@ TEST_F( PlayerTests, Push_RightAndVelocityHasNotMaxedOut_IncreasesXVelocity )
 
    _player->Push( Direction::Right );
 
-   EXPECT_EQ( _player->GetVelocityX(), 2. );
+   EXPECT_EQ( _player->GetVelocityX(), 2 );
 }
 
 TEST_F( PlayerTests, Push_DownRightAndVelocityHasNotMaxedOut_IncreasesXAndYVelocity )
@@ -112,8 +112,8 @@ TEST_F( PlayerTests, Push_DownRightAndVelocityHasNotMaxedOut_IncreasesXAndYVeloc
 
    _player->Push( Direction::DownRight );
 
-   EXPECT_EQ( _player->GetVelocityX(), 2. );
-   EXPECT_EQ( _player->GetVelocityY(), 2. );
+   EXPECT_EQ( _player->GetVelocityX(), 2 );
+   EXPECT_EQ( _player->GetVelocityY(), 2 );
 }
 
 TEST_F( PlayerTests, Push_DownAndVelocityHasNotMaxedOut_IncreasesYVelocity )
@@ -122,7 +122,7 @@ TEST_F( PlayerTests, Push_DownAndVelocityHasNotMaxedOut_IncreasesYVelocity )
 
    _player->Push( Direction::Down );
 
-   EXPECT_EQ( _player->GetVelocityY(), 2. );
+   EXPECT_EQ( _player->GetVelocityY(), 2 );
 }
 
 TEST_F( PlayerTests, Push_DownLeftAndVelocityHasNotMaxedOut_DecreasesXVelocityAndIncreasesYVelocity )
@@ -131,48 +131,48 @@ TEST_F( PlayerTests, Push_DownLeftAndVelocityHasNotMaxedOut_DecreasesXVelocityAn
 
    _player->Push( Direction::DownLeft );
 
-   EXPECT_EQ( _player->GetVelocityX(), -2. );
-   EXPECT_EQ( _player->GetVelocityY(), 2. );
+   EXPECT_EQ( _player->GetVelocityX(), -2 );
+   EXPECT_EQ( _player->GetVelocityY(), 2 );
 }
 
 TEST_F( PlayerTests, Push_LeftAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _playerDefs->AccelerationPerSecond = 100001.;
+   _playerDefs->AccelerationPerSecond = 100001;
    BuildPlayer();
 
    _player->Push( Direction::Left );
 
-   EXPECT_EQ( _player->GetVelocityX(), -100. );
+   EXPECT_EQ( _player->GetVelocityX(), -100 );
 }
 
 TEST_F( PlayerTests, Push_RightAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _playerDefs->AccelerationPerSecond = 100001.;
+   _playerDefs->AccelerationPerSecond = 100001;
    BuildPlayer();
 
    _player->Push( Direction::Right );
 
-   EXPECT_EQ( _player->GetVelocityX(), 100. );
+   EXPECT_EQ( _player->GetVelocityX(), 100 );
 }
 
 TEST_F( PlayerTests, Push_UpAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _playerDefs->AccelerationPerSecond = 10001.;
+   _playerDefs->AccelerationPerSecond = 10001;
    BuildPlayer();
 
    _player->Push( Direction::Up );
 
-   EXPECT_EQ( _player->GetVelocityY(), -100. );
+   EXPECT_EQ( _player->GetVelocityY(), -100 );
 }
 
 TEST_F( PlayerTests, Push_DownAndVelocityHasMaxedOut_ClampsToMaxVelocity )
 {
-   _playerDefs->AccelerationPerSecond = 10001.;
+   _playerDefs->AccelerationPerSecond = 10001;
    BuildPlayer();
 
    _player->Push( Direction::Down );
 
-   EXPECT_EQ( _player->GetVelocityY(), 100. );
+   EXPECT_EQ( _player->GetVelocityY(), 100 );
 }
 
 TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingLeftAndHasVelocityToSpare_DoesNotStop )
@@ -183,7 +183,7 @@ TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingLeftAndHasVelocityToSpare_Does
    _player->Push( Direction::Left );
    _player->ApplyFrictionX();
 
-   EXPECT_EQ( _player->GetVelocityX(), -2. );
+   EXPECT_EQ( _player->GetVelocityX(), -2 );
 }
 
 TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingRightAndHasVelocityToSpare_DoesNotStop )
@@ -194,7 +194,7 @@ TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingRightAndHasVelocityToSpare_Doe
    _player->Push( Direction::Right );
    _player->ApplyFrictionX();
 
-   EXPECT_EQ( _player->GetVelocityX(), 2. );
+   EXPECT_EQ( _player->GetVelocityX(), 2 );
 }
 
 TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingUpAndHasVelocityToSpare_DoesNotStop )
@@ -205,7 +205,7 @@ TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingUpAndHasVelocityToSpare_DoesNo
    _player->Push( Direction::Up );
    _player->ApplyFrictionY();
 
-   EXPECT_EQ( _player->GetVelocityY(), -2. );
+   EXPECT_EQ( _player->GetVelocityY(), -2 );
 }
 
 TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingDownAndHasVelocityToSpare_DoesNotStop )
@@ -216,51 +216,51 @@ TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingDownAndHasVelocityToSpare_Does
    _player->Push( Direction::Down );
    _player->ApplyFrictionY();
 
-   EXPECT_EQ( _player->GetVelocityY(), 2. );
+   EXPECT_EQ( _player->GetVelocityY(), 2 );
 }
 
 TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingLeftAndHasNoVelocityToSpare_Stops )
 {
-   _playerDefs->StartVelocityX = -1.;
-   _playerDefs->MaxVelocity = 2.;
+   _playerDefs->StartVelocityX = -1;
+   _playerDefs->MaxVelocity = 2;
    BuildPlayer();
 
    _player->ApplyFrictionX();
 
-   EXPECT_EQ( _player->GetVelocityX(), 0. );
+   EXPECT_EQ( _player->GetVelocityX(), 0 );
 }
 
 TEST_F( PlayerTests, ApplyFrictionX_PlayerIsMovingRightAndHasNoVelocityToSpare_Stops )
 {
-   _playerDefs->StartVelocityX = 1.;
-   _playerDefs->MaxVelocity = 2.;
+   _playerDefs->StartVelocityX = 1;
+   _playerDefs->MaxVelocity = 2;
    BuildPlayer();
 
    _player->ApplyFrictionX();
 
-   EXPECT_EQ( _player->GetVelocityX(), 0. );
+   EXPECT_EQ( _player->GetVelocityX(), 0 );
 }
 
 TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingUpAndHasNoVelocityToSpare_Stops )
 {
-   _playerDefs->StartVelocityY = -1.;
-   _playerDefs->MaxVelocity = 2.;
+   _playerDefs->StartVelocityY = -1;
+   _playerDefs->MaxVelocity = 2;
    BuildPlayer();
 
    _player->ApplyFrictionY();
 
-   EXPECT_EQ( _player->GetVelocityY(), 0. );
+   EXPECT_EQ( _player->GetVelocityY(), 0 );
 }
 
 TEST_F( PlayerTests, ApplyFrictionY_PlayerIsMovingDownAndHasNoVelocityToSpare_Stops )
 {
-   _playerDefs->StartVelocityY = 1.;
-   _playerDefs->MaxVelocity = 2.;
+   _playerDefs->StartVelocityY = 1;
+   _playerDefs->MaxVelocity = 2;
    BuildPlayer();
 
    _player->ApplyFrictionY();
 
-   EXPECT_EQ( _player->GetVelocityY(), 0. );
+   EXPECT_EQ( _player->GetVelocityY(), 0 );
 }
 
 TEST_F( PlayerTests, StopX_Always_SetsXVelocityToZero )
@@ -270,7 +270,7 @@ TEST_F( PlayerTests, StopX_Always_SetsXVelocityToZero )
    _player->Push( Direction::Right );
    _player->StopX();
 
-   EXPECT_EQ( _player->GetVelocityX(), 0. );
+   EXPECT_EQ( _player->GetVelocityX(), 0 );
 }
 
 TEST_F( PlayerTests, StopY_Always_SetsYVelocityToZero )
@@ -280,5 +280,5 @@ TEST_F( PlayerTests, StopY_Always_SetsYVelocityToZero )
    _player->Push( Direction::Up );
    _player->StopY();
 
-   EXPECT_EQ( _player->GetVelocityY(), 0. );
+   EXPECT_EQ( _player->GetVelocityY(), 0 );
 }

--- a/ConsoleGameTests/mock_Player.h
+++ b/ConsoleGameTests/mock_Player.h
@@ -12,7 +12,7 @@ public:
    MOCK_METHOD( void, ApplyFrictionY, (), ( override ) );
    MOCK_METHOD( void, StopX, (), ( override ) );
    MOCK_METHOD( void, StopY, (), ( override ) );
-   MOCK_METHOD( double, GetVelocityX, ( ), ( const, override ) );
-   MOCK_METHOD( double, GetVelocityY, ( ), ( const, override ) );
+   MOCK_METHOD( float, GetVelocityX, ( ), ( const, override ) );
+   MOCK_METHOD( float, GetVelocityY, ( ), ( const, override ) );
    MOCK_METHOD( ConsoleGame::Direction, GetDirection, ( ), ( const, override ) );
 };


### PR DESCRIPTION
This is more in line with what a real game would use. There's also no need to put `f` everywhere, most of them will be automatically cast to floats.